### PR TITLE
[JUNEAU-86] Avoid NPE stopping RestMicroservice.

### DIFF
--- a/juneau-microservice/juneau-microservice-server/src/main/java/org/apache/juneau/microservice/RestMicroservice.java
+++ b/juneau-microservice/juneau-microservice-server/src/main/java/org/apache/juneau/microservice/RestMicroservice.java
@@ -146,7 +146,7 @@ public class RestMicroservice extends Microservice {
 			@Override /* Thread */
 			public void run() {
 				try {
-					if (server.isStopping() || server.isStopped())
+					if (server == null || server.isStopping() || server.isStopped())
 						return;
 					onStopServer();
 					out(mb2, "StoppingServer");


### PR DESCRIPTION
[JUNEAU-86] Avoid NPE stopping RestMicroservice. You might need to ignore whitespace while viewing the patch in GH.