### PR TITLE
Added a complex example for XML serialization to core

### DIFF
--- a/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/pojo/PojoComplex.java
+++ b/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/pojo/PojoComplex.java
@@ -1,0 +1,75 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              * 
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
+package org.apache.juneau.examples.core.pojo;
+
+import java.util.*;
+
+import org.apache.juneau.annotation.*;
+
+/**
+ * TODO
+ * 
+ */
+public class PojoComplex {
+
+	private final String id;
+	private final Pojo innerPojo;
+	private final HashMap<String, List<Pojo>> values;
+	
+	
+	/**
+	 * TODO
+	 * 
+	 * @param id
+	 * @param innerPojo
+	 * @param values
+	 */
+	@BeanConstructor(properties = "id,innerPojo,values")
+	public PojoComplex(String id, Pojo innerPojo, HashMap<String, List<Pojo>> values) {
+		this.id = id;
+		this.innerPojo = innerPojo;
+		this.values = values;
+	}
+
+
+	/**
+	 * Bean property getter:  <property>id</property>.
+	 *
+	 * @return The value of the <property>id</property> property on this bean, or <jk>null</jk> if it is not set.
+	 */
+	public String getId() {
+		return id;
+	}
+
+
+	/**
+	 * Bean property getter:  <property>innerPojo</property>.
+	 *
+	 * @return The value of the <property>innerPojo</property> property on this bean, or <jk>null</jk> if it is not set.
+	 */
+	public Pojo getInnerPojo() {
+		return innerPojo;
+	}
+
+
+	/**
+	 * Bean property getter:  <property>values</property>.
+	 *
+	 * @return The value of the <property>values</property> property on this bean, or <jk>null</jk> if it is not set.
+	 */
+	public HashMap<String,List<Pojo>> getValues() {
+		return values;
+	}
+	
+	
+}

--- a/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/xml/XmlComplexExample.java
+++ b/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/xml/XmlComplexExample.java
@@ -1,0 +1,58 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              * 
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
+package org.apache.juneau.examples.core.xml;
+
+import java.util.*;
+
+import org.apache.juneau.examples.core.pojo.*;
+import org.apache.juneau.parser.*;
+import org.apache.juneau.serializer.*;
+import org.apache.juneau.xml.*;
+
+/**
+ * TODO
+ * 
+ */
+public class XmlComplexExample {
+	/**
+	 * TODO
+	 * 
+	 * @param args
+	 * @throws SerializeException 
+	 * @throws ParseException 
+	 */
+	public static void main(String[] args) throws SerializeException, ParseException {
+		
+		// Fill some data to a PojoComplex bean 
+		HashMap<String, List<Pojo>> values = new HashMap<>(); 
+		ArrayList<Pojo> setOne = new ArrayList<>();
+		setOne.add(new Pojo("1.1", "name1"));
+		setOne.add(new Pojo("1.1", "name2"));
+		ArrayList<Pojo> setTwo = new ArrayList<>();
+		setTwo.add(new Pojo("1.2", "name1"));
+		setTwo.add(new Pojo("1.2", "name2"));
+		values.put("setOne", setOne);
+		values.put("setTwo", setTwo);
+		PojoComplex pojoc = new PojoComplex("pojo", new Pojo("1.0", "name0"), values);
+		
+		// Serialize to human readable XML and print
+		String serial = XmlSerializer.DEFAULT_SQ_READABLE.serialize(pojoc);
+		System.out.println(serial);
+		
+		// Deserialize back to PojoComplex instance
+		PojoComplex obj = XmlParser.DEFAULT.parse(serial, PojoComplex.class);
+	
+		assert obj.getClass().equals(pojoc.getClass()); 
+
+	}
+}

--- a/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/xml/XmlComplexExample.java
+++ b/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/xml/XmlComplexExample.java
@@ -53,6 +53,10 @@ public class XmlComplexExample {
 		PojoComplex obj = XmlParser.DEFAULT.parse(serial, PojoComplex.class);
 	
 		assert obj.getClass().equals(pojoc.getClass()); 
+		assert obj.getInnerPojo().getId().equals(pojoc.getInnerPojo().getId());
+		
+		// The object above can be parsed thanks to the @BeanConstructor annotation on PojoComplex
+		// Using this approach, you can keep your POJOs immutable, and still serialize and deserialize them.
 
 	}
 }


### PR DESCRIPTION
There is a simple example for json serialization. I think better to add some complex example (Bean with maps of objects, aggregated instances ) then developer can run and get idea initially about complex bean serialization

Advice if there are modifications needs to be done