### PR TITLE
Added LN ST PE vars to svl-core

### DIFF
--- a/juneau-core/juneau-core-test/src/test/java/org/apache/juneau/svl/vars/LenVarTest.java
+++ b/juneau-core/juneau-core-test/src/test/java/org/apache/juneau/svl/vars/LenVarTest.java
@@ -1,0 +1,41 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              *
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
+package org.apache.juneau.svl.vars;
+
+import static org.junit.Assert.*;
+
+import org.apache.juneau.svl.*;
+import org.junit.*;
+
+public class LenVarTest {
+
+	//====================================================================================================
+	// test - Basic tests
+	//====================================================================================================
+	@Test
+	public void test() throws Exception {
+		VarResolver vr = new VarResolverBuilder().vars(LenVar.class, SystemPropertiesVar.class).build();
+
+		System.setProperty("LenVarTest.test", "foo bar");
+		System.setProperty("LenVarTest.test2", "1.2.3.4.5");
+
+		// $LN{stringArg} examples
+		assertEquals("1", vr.resolve("$LN{J}"));
+		assertEquals("len=7", vr.resolve("len=$LN{$S{LenVarTest.test}}"));
+		
+		// $LN{stringArg, delimiter} examples
+		assertEquals("5", vr.resolve("$LN{$S{LenVarTest.test2},.}"));
+
+		
+	}
+}

--- a/juneau-core/juneau-core-test/src/test/java/org/apache/juneau/svl/vars/PatternExtractVarTest.java
+++ b/juneau-core/juneau-core-test/src/test/java/org/apache/juneau/svl/vars/PatternExtractVarTest.java
@@ -1,0 +1,42 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              *
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
+package org.apache.juneau.svl.vars;
+
+import static org.junit.Assert.*;
+
+import org.apache.juneau.svl.*;
+import org.junit.*;
+
+public class PatternExtractVarTest {
+
+	//====================================================================================================
+	// test - Basic tests
+	//====================================================================================================
+	@Test
+	public void test() throws Exception {
+		VarResolver vr = new VarResolverBuilder().vars(PatternExtractVar.class, SystemPropertiesVar.class).build();
+
+		System.setProperty("PatternExtractVarTest.test", "foo bar");
+		System.setProperty("PatternExtractVarTest.test2", "size=23");
+
+		assertEquals("foo bar", vr.resolve("$PE{$S{PatternExtractVarTest.test},(.*),1}"));
+		
+		assertEquals("size", vr.resolve("$PE{$S{PatternExtractVarTest.test2},(.*)=([0-9]+),1}"));
+		assertEquals("23", vr.resolve("$PE{$S{PatternExtractVarTest.test2},(.*)=([0-9]+),2}"));
+		assertEquals("size=23", vr.resolve("$PE{$S{PatternExtractVarTest.test2},(.*)=([0-9]+),0}"));
+		assertEquals("", vr.resolve("$PE{$S{PatternExtractVarTest.test2},(.*)=([0-9]+),-2}"));
+		assertEquals("", vr.resolve("$PE{$S{PatternExtractVarTest.test2},(.*)=([0-9]+),54}"));
+		
+
+	}
+}

--- a/juneau-core/juneau-core-test/src/test/java/org/apache/juneau/svl/vars/SubstringVarTest.java
+++ b/juneau-core/juneau-core-test/src/test/java/org/apache/juneau/svl/vars/SubstringVarTest.java
@@ -1,0 +1,46 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              *
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
+package org.apache.juneau.svl.vars;
+
+import static org.junit.Assert.*;
+
+import org.apache.juneau.svl.*;
+import org.junit.*;
+
+public class SubstringVarTest {
+
+	//====================================================================================================
+	// test - Basic tests
+	//====================================================================================================
+	@Test
+	public void test() throws Exception {
+		VarResolver vr = new VarResolverBuilder().vars(SubstringVar.class, SystemPropertiesVar.class).build();
+
+		System.setProperty("SubstringVarTest.test", "foo bar");
+
+		// $ST{stringArg, start} examples
+		// Notice that -start also works here
+		assertEquals("o bar", vr.resolve("$ST{$S{SubstringVarTest.test},2}"));
+		assertEquals("", vr.resolve("$ST{$S{SubstringVarTest.test},24}"));
+		assertEquals("foo bar", vr.resolve("$ST{$S{SubstringVarTest.test},0}"));
+		assertEquals("", vr.resolve("$ST{$S{SubstringVarTest.test},-24}"));
+		assertEquals("bar", vr.resolve("$ST{$S{SubstringVarTest.test},-3}"));
+		assertEquals("foo bar", vr.resolve("$ST{$S{SubstringVarTest.test},-7}"));
+		
+		// $ST{stringArg, start, end}
+		assertEquals("foo bar", vr.resolve("$ST{$S{SubstringVarTest.test},0,7}"));
+		assertEquals("oo", vr.resolve("$ST{$S{SubstringVarTest.test},1,3}"));
+		assertEquals("", vr.resolve("$ST{$S{SubstringVarTest.test},-2, 2}"));
+		
+	}
+}

--- a/juneau-core/juneau-svl/src/main/java/org/apache/juneau/svl/VarResolverBuilder.java
+++ b/juneau-core/juneau-svl/src/main/java/org/apache/juneau/svl/VarResolverBuilder.java
@@ -72,9 +72,12 @@ public class VarResolverBuilder {
 	 * 	<li>{@link CoalesceVar}
 	 * 	<li>{@link PatternMatchVar}
 	 * 	<li>{@link PatternReplaceVar}
+	 * 	<li>{@link PatternExtractVar}
 	 * 	<li>{@link UpperCaseVar}
 	 * 	<li>{@link LowerCaseVar}
 	 * 	<li>{@link NotEmptyVar}
+	 * 	<li>{@link LenVar}
+	 * 	<li>{@link SubstringVar}
 	 * </ul>
 	 *
 	 * @return This object (for method chaining).
@@ -90,9 +93,12 @@ public class VarResolverBuilder {
 			CoalesceVar.class,
 			PatternMatchVar.class,
 			PatternReplaceVar.class,
+			PatternExtractVar.class,
 			UpperCaseVar.class,
 			LowerCaseVar.class,
-			NotEmptyVar.class);
+			NotEmptyVar.class,
+			LenVar.class,
+			SubstringVar.class);
 	}
 
 	/**

--- a/juneau-core/juneau-svl/src/main/java/org/apache/juneau/svl/vars/LenVar.java
+++ b/juneau-core/juneau-svl/src/main/java/org/apache/juneau/svl/vars/LenVar.java
@@ -1,0 +1,80 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              *
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
+package org.apache.juneau.svl.vars;
+
+import static org.apache.juneau.internal.ThrowableUtils.*;
+
+import java.util.regex.*;
+
+import org.apache.juneau.svl.*;
+
+/**
+ * A transformational variable resolver that returns character count or list count (using given delimiter).
+ *
+ * <p>
+ * The format for this var is one of the following:
+ * <ul>
+ * 	<li><js>"$LN{arg}"</js>
+ * 	<li><js>"$LN{arg, delimiter}"</js>
+ * </ul>
+ *
+ * <p>
+ * 
+ *
+ * <h5 class='section'>Example:</h5>
+ * <p class='bcode w800'>
+ * 	<jc>// Create a variable resolver that resolves system properties and $SW vars.</jc>
+ * 	VarResolver r = VarResolver.<jsm>create</jsm>().vars(LenVar.<jk>class</jk>, SystemPropertiesVar.<jk>class</jk>).build();
+ *
+ * 	<jc>// Use it!</jc>
+ * 	System.<jsf>out</jsf>.println(r.resolve(<js>"Parts = $LN{$P{os.version},.} Chars = $LN{$P{os.version}}"</js>));
+ * </p>
+ *
+ * <p>
+ * Since this is a {@link MultipartVar}, any variables contained in the result will be recursively resolved.
+ * <br>Likewise, if the arguments contain any variables, those will be resolved before they are passed to this var.
+ *
+ * <h5 class='section'>See Also:</h5>
+ * <ul>
+ * 	<li class='link'>{@doc juneau-svl.SvlVariables}
+ * </ul>
+ */
+public class LenVar extends MultipartVar {
+
+	/** The name of this variable. */
+	public static final String NAME = "LN";
+
+	/**
+	 * Constructor.
+	 */
+	public LenVar() {
+		super(NAME);
+	}
+
+	@Override /* MultipartVar */
+	public String resolve(VarResolverSession session, String[] args) {
+		if (args.length > 2)
+			illegalArg("Invalid number of arguments passed to $LN var.  Must have 1 or 2 arguments.");
+		
+		int len = 0;
+		String stringArg = args[0];
+		if (args.length == 1) 
+			len = stringArg.length();
+		else if (args.length == 2) { 
+			//delimiter is given 
+			String delimiter = Pattern.quote(args[1]);
+			len = stringArg.trim().split(delimiter).length;
+		}
+		return String.valueOf(len);
+	}
+}

--- a/juneau-core/juneau-svl/src/main/java/org/apache/juneau/svl/vars/PatternExtractVar.java
+++ b/juneau-core/juneau-svl/src/main/java/org/apache/juneau/svl/vars/PatternExtractVar.java
@@ -1,0 +1,83 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              *
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
+package org.apache.juneau.svl.vars;
+
+import static org.apache.juneau.internal.ThrowableUtils.*;
+
+import java.util.regex.*;
+
+import org.apache.juneau.svl.*;
+
+/**
+ * A transformational variable that returns matched regex groups by given index.
+ *
+ * <p>
+ * The format for this var:
+ * <ul>
+ * 	<li><js>"$PE{arg, pattern, groupIndex}"</js>
+ * </ul>
+ *
+ * <p>
+ * The pattern can be any string optionally containing <js>'*'</js> or <js>'?'</js> representing any or one character
+ * respectively.
+ *
+ * <h5 class='section'>Example:</h5>
+ * <p class='bcode w800'>
+ * 	<jc>// Create a variable resolver that resolves system properties and $SW vars.</jc>
+ * 	VarResolver r = VarResolver.<jsm>create</jsm>().vars(PatternExtractVar.<jk>class</jk>, SystemPropertiesVar.<jk>class</jk>).build();
+ *
+ * 	<jc>// Use it!</jc>
+ * 	System.<jsf>out</jsf>.println(r.resolve(<js>"Update = $PE{$P{java.version},_([0-9]+),1}!"</js>));
+ * </p>
+ *
+ * <p>
+ * Since this is a {@link MultipartVar}, any variables contained in the result will be recursively resolved.
+ * <br>Likewise, if the arguments contain any variables, those will be resolved before they are passed to this var.
+ *
+ * <h5 class='section'>See Also:</h5>
+ * <ul>
+ * 	<li class='link'>{@doc juneau-svl.SvlVariables}
+ * </ul>
+ */
+public class PatternExtractVar extends MultipartVar {
+
+	/** The name of this variable. */
+	public static final String NAME = "PE";
+
+	/**
+	 * Constructor.
+	 */
+	public PatternExtractVar() {
+		super(NAME);
+	}
+
+	@Override /* MultipartVar */
+	public String resolve(VarResolverSession session, String[] args) {
+		if (args.length < 3)
+			illegalArg("Invalid number of arguments passed to $PE var.  Must have 3 arguments.");
+
+		String stringArg = args[0];
+		String pattern = args[1];
+		String result = "";
+		int groupId = Integer.parseInt(args[2]);
+		
+		Pattern p = Pattern.compile(pattern.replace("*", ".*").replace("?", "."));
+		Matcher m = p.matcher(stringArg);
+			
+		if (m.find() && groupId <= m.groupCount() && groupId >= 0) {
+			result = m.group(groupId);
+		}
+		
+		return result;
+	}
+}

--- a/juneau-core/juneau-svl/src/main/java/org/apache/juneau/svl/vars/SubstringVar.java
+++ b/juneau-core/juneau-svl/src/main/java/org/apache/juneau/svl/vars/SubstringVar.java
@@ -1,0 +1,87 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              *
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
+package org.apache.juneau.svl.vars;
+
+import static org.apache.juneau.internal.ThrowableUtils.*;
+
+import java.util.regex.*;
+
+import org.apache.juneau.svl.*;
+
+/**
+ * A transformational variable resolver that returns substring for given start and end (optional)
+ *
+ * <p>
+ * The format for this var is one of the following:
+ * <ul>
+ * 	<li><js>"$ST{arg, start}"</js>
+ * 	<li><js>"$ST{arg, start, end}"</js>
+ * </ul>
+ *
+ * <p>
+ * 
+ *
+ * <h5 class='section'>Example:</h5>
+ * <p class='bcode w800'>
+ * 	<jc>// Create a variable resolver that resolves system properties and $SW vars.</jc>
+ * 	VarResolver r = VarResolver.<jsm>create</jsm>().vars(SubstringVar.<jk>class</jk>, SystemPropertiesVar.<jk>class</jk>).build();
+ *
+ * 	<jc>// Use it!</jc>
+ * 	System.<jsf>out</jsf>.println(r.resolve(<js>"Version = $ST{$P{java.version}, 0, 3}"</js>));
+ * </p>
+ *
+ * <p>
+ * Since this is a {@link MultipartVar}, any variables contained in the result will be recursively resolved.
+ * <br>Likewise, if the arguments contain any variables, those will be resolved before they are passed to this var.
+ *
+ * <h5 class='section'>See Also:</h5>
+ * <ul>
+ * 	<li class='link'>{@doc juneau-svl.SvlVariables}
+ * </ul>
+ */
+public class SubstringVar extends MultipartVar {
+
+	/** The name of this variable. */
+	public static final String NAME = "ST";
+
+	/**
+	 * Constructor.
+	 */
+	public SubstringVar() {
+		super(NAME);
+	}
+
+	@Override /* MultipartVar */
+	public String resolve(VarResolverSession session, String[] args) {
+		if (args.length > 3)
+			illegalArg("Invalid number of arguments passed to $ST var.  Must have 1 or 2 arguments.");
+		
+		
+		String stringArg = args[0];
+		String result = "";
+		if (args.length == 2) {
+			int start = Integer.parseInt(args[1]);
+			if (start >= 0 && start <= stringArg.length())
+				result = stringArg.substring(start);
+			if (start < 0 && -start <= stringArg.length())
+				result = stringArg.substring(stringArg.length() + start);
+		}
+		else if (args.length == 3) { 
+			int start = Integer.parseInt(args[1]);
+			int end = Integer.parseInt(args[2]);
+			if (start >= 0 && start < stringArg.length() && end >= 0 && end <= stringArg.length() && start < end)
+				result = stringArg.substring(start, end);
+		}
+		return result;
+	}
+}


### PR DESCRIPTION
This is related to last mail thread.

$LN = for getting no of chars of list size (using delimiter)
$ST = substring using start and end(optional) indexes. And python like -start works here
eg `arg=apple`   `start=-2` returns `le`

$PE = extracting matched regex groups

Let me know if some modifications required