### PR TITLE
Adding more samples on rdf serializer and adding clear comments

### DIFF
--- a/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/rdf/RdfComplexExample.java
+++ b/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/rdf/RdfComplexExample.java
@@ -14,6 +14,7 @@ package org.apache.juneau.examples.core.rdf;
 
 import org.apache.juneau.examples.core.pojo.*;
 import org.apache.juneau.jena.RdfSerializer;
+import org.apache.juneau.jena.RdfXmlAbbrevSerializer;
 import org.apache.juneau.jena.RdfXmlSerializer;
 
 import java.util.ArrayList;
@@ -46,8 +47,58 @@ public class RdfComplexExample {
         PojoComplex pojoc = new PojoComplex("pojo", new Pojo("1.0", "name0"), values);
 
         // this creates an RDF serializer with the default XML structure
+        /**Produces
+         * <rdf:RDF
+         * xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         * xmlns:j="http://www.apache.org/juneau/"
+         * xmlns:jp="http://www.apache.org/juneaubp/" >
+         * <rdf:Description rdf:nodeID="A0">
+         * <jp:name>name1</jp:name>
+         * <jp:id>1.1</jp:id>
+         * </rdf:Description>
+         * <rdf:Description rdf:nodeID="A1">
+         * <jp:innerPojo rdf:nodeID="A2"/>
+         * <jp:values rdf:nodeID="A3"/>
+         * <jp:id>pojo</jp:id>
+         * </rdf:Description>
+         * <rdf:Description rdf:nodeID="A3">
+         * <jp:setOne rdf:nodeID="A4"/>
+         * <jp:setTwo rdf:nodeID="A5"/>
+         * </rdf:Description>
+         * <rdf:Description rdf:nodeID="A6">
+         * <jp:name>name2</jp:name>
+         * <jp:id>1.1</jp:id>
+         * </rdf:Description>
+         * <rdf:Description rdf:nodeID="A2">
+         * <jp:name>name0</jp:name>
+         * <jp:id>1.0</jp:id>
+         * </rdf:Description>
+         * <rdf:Description rdf:nodeID="A7">
+         * <jp:name>name2</jp:name>
+         * <jp:id>1.2</jp:id>
+         * </rdf:Description>
+         * <rdf:Description rdf:nodeID="A4">
+         * <rdf:_2 rdf:nodeID="A6"/>
+         * <rdf:_1 rdf:nodeID="A0"/>
+         * <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+         * </rdf:Description>
+         * <rdf:Description rdf:nodeID="A5">
+         * <rdf:_2 rdf:nodeID="A7"/>
+         * <rdf:_1 rdf:nodeID="A8"/>
+         * <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq"/>
+         * </rdf:Description>
+         * <rdf:Description rdf:nodeID="A8">
+         * <jp:name>name1</jp:name>
+         * <jp:id>1.2</jp:id>
+         * </rdf:Description>
+         * </rdf:RDF>
+         */
         RdfSerializer rdfSerializer = RdfXmlSerializer.DEFAULT;
         // This will show the final output from the bean
         System.out.println(rdfSerializer.serialize(pojoc));
+
+        //Usage of RdfXmlAbbrevSerializer.
+        String rdfXml = RdfXmlAbbrevSerializer.DEFAULT.serialize(pojoc);
+        System.out.println(rdfXml);
     }
 }

--- a/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/rdf/RdfExample.java
+++ b/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/rdf/RdfExample.java
@@ -35,8 +35,82 @@ public class RdfExample {
 	public static void main(String[] args) throws Exception {
 		Pojo pojo = new Pojo("rdf","This is RDF format.");
 		// this creates an RDF serializer with the default XML structure
+		/**Produces
+		 * <rdf:RDF
+		 * xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+		 * xmlns:j="http://www.apache.org/juneau/"
+		 * xmlns:jp="http://www.apache.org/juneaubp/" >
+		 * <rdf:Description rdf:nodeID="A0">
+		 * <jp:name>This is RDF format.</jp:name>
+		 * <jp:id>rdf</jp:id>
+		 * </rdf:Description>
+		 * </rdf:RDF>
+		 */
 		RdfSerializer rdfSerializer = RdfXmlSerializer.DEFAULT;
 		// This will show the final output from the bean
 		System.out.println(rdfSerializer.serialize(pojo));
+
+		/**Produces
+		 * <rdf:RDF
+		 * xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+		 * xmlns:j="http://www.apache.org/juneau/"
+		 * xmlns:jp="http://www.apache.org/juneaubp/">
+		 * <rdf:Description>
+		 * <jp:name>This is RDF format.</jp:name>
+		 * <jp:id>rdf</jp:id>
+		 * </rdf:Description>
+		 * </rdf:RDF>
+		 */
+		String rdfXml = RdfXmlAbbrevSerializer.DEFAULT.serialize(pojo);
+		System.out.println(rdfXml);
+
+		// Deserialize back to Pojo instance type.
+		Pojo xmlAbParsed = RdfXmlParser.DEFAULT.parse(rdfXml,Pojo.class);
+		assert xmlAbParsed.getClass().equals(pojo.getClass());
+		assert xmlAbParsed.getId().equals(pojo.getId());
+
+		/**Produces
+		 * @prefix jp:      <http://www.apache.org/juneaubp/> .
+		 * @prefix j:       <http://www.apache.org/juneau/> .
+		 *
+		 * []    jp:id   "rdf" ;
+		 * jp:name "This is RDF format." .
+		 */
+		String rdfN3 = N3Serializer.DEFAULT.serialize(pojo);
+		System.out.println(rdfN3);
+
+		// Deserialize back to Pojo instance type.
+		Pojo n3parsed = N3Parser.DEFAULT.parse(rdfN3,Pojo.class);
+		assert n3parsed.getClass().equals(pojo.getClass());
+		assert n3parsed.getId().equals(pojo.getId());
+
+		/**Produces
+		 *_:A5ecded4fX3aX167a62fdefeX3aXX2dX7ffc <http://www.apache.org/juneaubp/name> "This is RDF format." .
+		 *_:A5ecded4fX3aX167a62fdefeX3aXX2dX7ffc <http://www.apache.org/juneaubp/id> "rdf" .
+		 */
+		String rdfNTriple = NTripleSerializer.DEFAULT.serialize(pojo);
+		System.out.println(rdfNTriple);
+
+		// Deserialize back to Pojo instance type.
+		Pojo nTripleparsed = NTripleParser.DEFAULT.parse(rdfNTriple,Pojo.class);
+		assert nTripleparsed.getClass().equals(pojo.getClass());
+		assert nTripleparsed.getId().equals(pojo.getId());
+
+		/**
+		 * @prefix jp:      <http://www.apache.org/juneaubp/> .
+		 * @prefix j:       <http://www.apache.org/juneau/> .
+		 *
+		 * []    jp:id   "rdf" ;
+		 * jp:name "This is RDF format." .
+		 */
+		String rdfTurtle = TurtleSerializer.DEFAULT.serialize(pojo);
+		System.out.println(rdfTurtle);
+
+		// Deserialize back to Pojo instance type.
+		Pojo turtleparsed = TurtleParser.DEFAULT.parse(rdfTurtle,Pojo.class);
+		assert turtleparsed.getClass().equals(pojo.getClass());
+		assert turtleparsed.getId().equals(pojo.getId());
+
+		
 	}
 }


### PR DESCRIPTION
@jamesbognar  added more examples on rdf.And what I see on the http://juneau.apache.org/#marshall.html web page rdf samples seems to be deprecated.Do we need to refactor them.

RDF samples in marshall.html which seems to be not working with current snapshots on marshall-rdf module.

```
// A simple bean
	public class Person {
		public String name = "John Smith";
		public int age = 21;
	}
	
	// Serialize a bean to JSON, XML, or HTML
	Person p = new Person();

	// Produces:
	// <rdf:RDF
	//  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
	//  xmlns:jp="http://www.apache.org/juneaubp/"
	//  xmlns:j="http://www.apache.org/juneau/">
	// 	<rdf:Description>
	// 		<jp:name>John Smith</jp:name>
	// 		<jp:age>21</jp:age>
	// 	</rdf:Description>
	// </rdf:RDF>
	String rdfXml = RdfSerializer.DEFAULT_XMLABBREV.serialize(p);
	
	// Produces:
	// @prefix jp:      <http://www.apache.org/juneaubp/> .
	// @prefix j:       <http://www.apache.org/juneau/> .
	//	[]    jp:age  "21" ;
	//	      jp:name "John Smith" .
	String rdfN3 = RdfSerializer.DEFAULT_N3.serialize(p);

	// Produces:
	// _:A3bf53c85X3aX157cf407e2dX3aXX2dX7ffd <http://www.apache.org/juneaubp/name> "John Smith" .
	// _:A3bf53c85X3aX157cf407e2dX3aXX2dX7ffd <http://www.apache.org/juneaubp/age> "21" .
	String rdfNTriple = RdfSerializer.DEFAULT_NTRIPLE.serialize(p);
```

