### PR TITLE
fixing issues in dto samples

### DIFF
--- a/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/dto/DtoExample.java
+++ b/juneau-examples/juneau-examples-core/src/main/java/org/apache/juneau/examples/core/dto/DtoExample.java
@@ -1,3 +1,15 @@
+// ***************************************************************************************************************************
+// * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file *
+// * distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file        *
+// * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance            *
+// * with the License.  You may obtain a copy of the License at                                                              *
+// *                                                                                                                         *
+// *  http://www.apache.org/licenses/LICENSE-2.0                                                                             *
+// *                                                                                                                         *
+// * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an  *
+// * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the        *
+// * specific language governing permissions and limitations under the License.                                              *
+// ***************************************************************************************************************************
 package org.apache.juneau.examples.core.dto;
 
 import org.apache.juneau.dto.atom.Feed;
@@ -12,9 +24,17 @@ import static org.apache.juneau.dto.atom.AtomBuilder.*;
 import static org.apache.juneau.dto.html5.HtmlBuilder.*;
 import static org.apache.juneau.dto.swagger.SwaggerBuilder.*;
 
+/**
+ * Sample class which shows the usage of DTO module which is a
+ * Sub module of the core.
+ */
 public class DtoExample {
 
-    @SuppressWarnings("unused")
+    /**
+     * DTO Samples
+     * @param args
+     * @throws Exception
+     */
 	public static void main(String[] args) throws Exception {
 
         //Produces
@@ -102,8 +122,29 @@ public class DtoExample {
                         );
 
         // Serialize to ATOM/XML
+        /**
+         * <feed>
+         *     <title>Example apache Juneau feed</title>
+         *     <link href="http://juneau.apache.org/" hreflang="en" rel="alternate" type="text/html"/>
+         *     <link href="http://juneau.apache.org/feed.atom" rel="self" type="application/atom+xml"/>
+         *     <rights>Copyright (c) 2016, Apache Foundation</rights>
+         *     <author><name>Juneau_Commiter</name></author>
+         *     <updated>2018-12-15T08:52:05Z</updated>
+         *     <id>tag:juneau.apache.org</id>
+         *     <subtitle type="html">Describes <em>stuff</em> about Juneau</subtitle>
+         *     <entry>
+         *          <title>Juneau ATOM specification snapshot</title>
+         *          <updated>2016-01-02T03:04:05Z</updated>
+         *          <id>tag:juneau.sample.com,2013:1.2345</id>
+         *          <published>2016-01-02T03:04:05Z</published>
+         *          <content lang="en" base="http://www.apache.org/" type="xhtml">
+         *              <div><p><i>[Update: Juneau supports ATOM.]</i></p></div>
+         *          </content>
+         *     </entry>
+         * </feed>
+         */
         String atomXml = XmlSerializer.DEFAULT.serialize(feed);
-
+        System.out.print(atomXml);
 
         Swagger swagger = swagger()
                 .swagger("2.0")


### PR DESCRIPTION
@jamesbognar James on Juneau-rest module => Juneau-rest-server-jaxrs Basic provider some serializers like HtmlSerializer,UonSerializer missing and in parsers section JsoParser ,UonParser are missing do we need to add them am talking about below class
https://github.com/apache/juneau/blob/master/juneau-rest/juneau-rest-server-jaxrs/src/main/java/org/apache/juneau/rest/jaxrs/BasicProvider.java)