### PR TITLE
adding missing serializers and parsers in to rest-jaxrs module

### DIFF
--- a/juneau-rest/juneau-rest-server-jaxrs/src/main/java/org/apache/juneau/rest/jaxrs/BasicProvider.java
+++ b/juneau-rest/juneau-rest-server-jaxrs/src/main/java/org/apache/juneau/rest/jaxrs/BasicProvider.java
@@ -20,6 +20,8 @@ import org.apache.juneau.jso.*;
 import org.apache.juneau.json.*;
 import org.apache.juneau.rest.*;
 import org.apache.juneau.soap.*;
+import org.apache.juneau.uon.UonParser;
+import org.apache.juneau.uon.UonSerializer;
 import org.apache.juneau.urlencoding.*;
 import org.apache.juneau.xml.*;
 import org.apache.juneau.xmlschema.XmlSchemaDocSerializer;
@@ -63,12 +65,15 @@ import org.apache.juneau.xmlschema.XmlSchemaDocSerializer;
 		HtmlDocSerializer.class,
 		UrlEncodingSerializer.class,
 		SoapXmlSerializer.class,
+		HtmlSerializer.class,
+		UonSerializer.class,
 		JsoSerializer.class
 	},
 	parsers={
 		JsonParser.class,
 		XmlParser.class,
 		HtmlParser.class,
+		UonParser.class,
 		UrlEncodingParser.class,
 	}
 )


### PR DESCRIPTION
@jamesbognar   James any idea why core samples are missing in these pages.And most of the images of core samples are also out dated

http://juneau.apache.org/site/apidocs-7.2.2/overview-summary.html#juneau-examples-core,
http://juneau.apache.org/#examples.html