### PR TITLE
Upgrade to Jena 3.x

### DIFF
--- a/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfCommon.java
+++ b/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfCommon.java
@@ -83,7 +83,7 @@ public interface RdfCommon {
 	 * 		Will make a decision on exactly which writer to use (pretty writer, plain writer or simple writer) when
 	 * 		created.
 	 * 		Default is the pretty writer but can be overridden with system property
-	 * 		<code>com.hp.hpl.jena.n3.N3JenaWriter.writer</code>.
+	 * 		<code>org.apache.jena.n3.N3JenaWriter.writer</code>.
 	 * 	<li>
 	 * 		<js>"N3-PP"</js> - Name of the N3 pretty writer.
 	 * 		The pretty writer uses a frame-like layout, with prefixing, clustering like properties and embedding

--- a/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfParserBuilder.java
+++ b/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfParserBuilder.java
@@ -136,7 +136,7 @@ public class RdfParserBuilder extends ReaderParserBuilder {
 	 * 		Will make a decision on exactly which writer to use (pretty writer, plain writer or simple writer) when
 	 * 		created.
 	 * 		Default is the pretty writer but can be overridden with system property
-	 * 		<code>com.hp.hpl.jena.n3.N3JenaWriter.writer</code>.
+	 * 		<code>org.apache.jena.n3.N3JenaWriter.writer</code>.
 	 * 	<li>
 	 * 		<js>"N3-PP"</js> - Name of the N3 pretty writer.
 	 * 		The pretty writer uses a frame-like layout, with prefixing, clustering like properties and embedding

--- a/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfParserSession.java
+++ b/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfParserSession.java
@@ -17,13 +17,12 @@ import static org.apache.juneau.jena.Constants.*;
 
 import java.util.*;
 
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.util.iterator.*;
 import org.apache.juneau.*;
 import org.apache.juneau.parser.*;
 import org.apache.juneau.transform.*;
 import org.apache.juneau.xml.*;
-
-import com.hp.hpl.jena.rdf.model.*;
-import com.hp.hpl.jena.util.iterator.*;
 
 /**
  * Session object that lives for the duration of a single use of {@link RdfParser}.

--- a/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfSerializerBuilder.java
+++ b/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfSerializerBuilder.java
@@ -231,7 +231,7 @@ public class RdfSerializerBuilder extends WriterSerializerBuilder {
 	 * 		Will make a decision on exactly which writer to use (pretty writer, plain writer or simple writer) when
 	 * 		created.
 	 * 		Default is the pretty writer but can be overridden with system property
-	 * 		<code>com.hp.hpl.jena.n3.N3JenaWriter.writer</code>.
+	 * 		<code>org.apache.jena.n3.N3JenaWriter.writer</code>.
 	 * 	<li>
 	 * 		<js>"N3-PP"</js> - Name of the N3 pretty writer.
 	 * 		The pretty writer uses a frame-like layout, with prefixing, clustering like properties and embedding

--- a/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfSerializerSession.java
+++ b/juneau-core/juneau-marshall-rdf/src/main/java/org/apache/juneau/jena/RdfSerializerSession.java
@@ -17,6 +17,7 @@ import static org.apache.juneau.jena.RdfSerializer.*;
 
 import java.util.*;
 
+import org.apache.jena.rdf.model.*;
 import org.apache.juneau.*;
 import org.apache.juneau.internal.*;
 import org.apache.juneau.jena.annotation.*;
@@ -24,8 +25,6 @@ import org.apache.juneau.serializer.*;
 import org.apache.juneau.transform.*;
 import org.apache.juneau.xml.*;
 import org.apache.juneau.xml.annotation.*;
-
-import com.hp.hpl.jena.rdf.model.*;
 
 /**
  * Session object that lives for the duration of a single use of {@link RdfSerializer}.

--- a/juneau-doc/docs/docs.txt
+++ b/juneau-doc/docs/docs.txt
@@ -34,7 +34,7 @@ RFC2616 = https://www.w3.org/Protocols/rfc2616/rfc2616.html, Hypertext Transfer 
 RFC2616.section9 = https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html, RFC2616/9
 RFC2616.section14.1 = https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html, RFC2616/14.1
 JsonSchemaValidation = http://json-schema.org/latest/json-schema-validation.html, JSON Schema Org > Validation
-ARP = http://jena.sourceforge.net/javadoc/com/hp/hpl/jena/rdf/arp
+ARP = https://jena.apache.org/documentation/io/arp.html
 
 HTML5 = https://www.w3.org/TR/html5
 HTML5.text-level-semantics = https://www.w3.org/TR/html5/text-level-semantics.html

--- a/juneau-doc/src/main/javadoc/overview.html
+++ b/juneau-doc/src/main/javadoc/overview.html
@@ -521,7 +521,7 @@
 	<li>Minimal library dependencies: 
 		<ul>
 			<li><b>juneau-marshall</b>, <b>juneau-dto</b>, <b>juneau-svl</b>, <b>juneau-config</b> - No external dependencies.  Entirely self-contained.
-			<li><b>juneau-marshall-rdf</b> - Optional RDF support.  Requires Apache Jena 2.7.1+.
+			<li><b>juneau-marshall-rdf</b> - Optional RDF support.  Requires Apache Jena 3+.
 			<li><b>juneau-rest-server</b> - Any Servlet 3.1.0+ container.
 			<li><b>juneau-rest-client</b> - Apache HttpClient 4.5+.
 			<li><b>juneau-microservice</b> - Eclipse Jetty.

--- a/juneau-doc/src/main/javadoc/resources/docs.txt
+++ b/juneau-doc/src/main/javadoc/resources/docs.txt
@@ -1,4 +1,4 @@
-ARP =  http://jena.sourceforge.net/javadoc/com/hp/hpl/jena/rdf/arp, arp
+ARP =  https://jena.apache.org/documentation/io/arp.html, arp
 ConfigurableProperties = #juneau-marshall.ConfigurableProperties, Configurable Properties
 DefaultRestSvlVariables = #DefaultRestSvlVariables, Default REST SVL Variables
 GFM = https://help.github.com/articles/github-flavored-markdown, GFM syntax

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 
 		<jaxb.version>2.3.1</jaxb.version>
-		<jena.version>2.7.1</jena.version>
+		<jena.version>3.10.0</jena.version>
 		<junit.version>4.11</junit.version>
 		<jaxrs.version>1.1.1</jaxrs.version>
 		<servlet.version>3.1.0</servlet.version>


### PR DESCRIPTION
I noticed that Juneau relies on a rather old version of Jena (2.7). Version 3.10 was just released, and this PR updates both the code and the corresponding documentation to the updated version of Jena.

In addition to moving onto the current major release series of Jena, this will also mean that more of the RDF 1.1 syntaxes (e.g. JSON-LD) could be supported. Jena 3.x does require Java 8, but it seems as though Juneau also has that requirement.