### PR TITLE
Make it possible to build Juneau on JDK 11

### DIFF
--- a/juneau-core/juneau-config/pom.xml
+++ b/juneau-core/juneau-config/pom.xml
@@ -82,7 +82,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.2.201409121644</version>
+				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>

--- a/juneau-core/juneau-core-test/pom.xml
+++ b/juneau-core/juneau-core-test/pom.xml
@@ -60,6 +60,10 @@
 			<optional>false</optional>
 		</dependency>
 		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
@@ -88,6 +92,9 @@
 					<includes>
 						<include>**/*Test.class</include>
 					</includes>
+					<systemPropertyVariables>
+						<java.locale.providers>JRE,COMPAT,SPI,CLDR</java.locale.providers>
+					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -117,7 +124,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.2.201409121644</version>
+				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>

--- a/juneau-core/juneau-dto/pom.xml
+++ b/juneau-core/juneau-dto/pom.xml
@@ -34,6 +34,10 @@
 			<artifactId>juneau-marshall</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<properties>
@@ -77,7 +81,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.2.201409121644</version>
+				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>

--- a/juneau-core/juneau-marshall-rdf/pom.xml
+++ b/juneau-core/juneau-marshall-rdf/pom.xml
@@ -86,7 +86,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.2.201409121644</version>
+				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>

--- a/juneau-core/juneau-marshall/pom.xml
+++ b/juneau-core/juneau-marshall/pom.xml
@@ -36,6 +36,13 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
+	<dependencies>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -69,7 +76,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.2.201409121644</version>
+				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>

--- a/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/BeanMeta.java
+++ b/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/BeanMeta.java
@@ -18,7 +18,9 @@ import static org.apache.juneau.internal.CollectionUtils.*;
 import static org.apache.juneau.internal.StringUtils.*;
 import static org.apache.juneau.BeanMeta.MethodType.*;
 
-import java.beans.*;
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.io.*;
 import java.lang.reflect.*;
 import java.util.*;

--- a/juneau-core/juneau-svl/pom.xml
+++ b/juneau-core/juneau-svl/pom.xml
@@ -77,7 +77,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.2.201409121644</version>
+				<version>0.8.2</version>
 				<executions>
 					<execution>
 						<id>default-prepare-agent</id>

--- a/juneau-examples/juneau-examples-rest-jetty/pom.xml
+++ b/juneau-examples/juneau-examples-rest-jetty/pom.xml
@@ -59,6 +59,10 @@
 
 		<!-- Other -->
 		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/juneau-microservice/juneau-microservice-core/src/main/java/org/apache/juneau/microservice/Microservice.java
+++ b/juneau-microservice/juneau-microservice-core/src/main/java/org/apache/juneau/microservice/Microservice.java
@@ -170,8 +170,7 @@ public class Microservice implements ConfigEventListener {
 				}
 			} else {
 				// Otherwise, read from manifest file in the jar file containing the main class.
-				URLClassLoader cl = (URLClassLoader)getClass().getClassLoader();
-				URL url = cl.findResource("META-INF/MANIFEST.MF");
+				URL url = getClass().getResource("META-INF/MANIFEST.MF");
 				if (url != null) {
 					try {
 						m.read(url.openStream());

--- a/juneau-microservice/juneau-microservice-test/pom.xml
+++ b/juneau-microservice/juneau-microservice-test/pom.xml
@@ -76,6 +76,14 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>javax.activation-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.activation</groupId>
+			<artifactId>javax.activation</artifactId>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/juneau-rest/juneau-rest-client/pom.xml
+++ b/juneau-rest/juneau-rest-client/pom.xml
@@ -39,6 +39,14 @@
 			<artifactId>httpclient</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>javax.activation-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.activation</groupId>
+			<artifactId>javax.activation</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/juneau-rest/juneau-rest-server/pom.xml
+++ b/juneau-rest/juneau-rest-server/pom.xml
@@ -48,7 +48,18 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>javax.activation-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.activation</groupId>
+			<artifactId>javax.activation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.juneau</groupId>
 			<artifactId>juneau-core-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 
+		<jaxb.version>2.3.1</jaxb.version>
 		<jena.version>2.7.1</jena.version>
 		<junit.version>4.11</junit.version>
 		<jaxrs.version>1.1.1</jaxrs.version>
@@ -74,6 +75,12 @@
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
 				<version>${servlet.version}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>${jaxb.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
@@ -328,7 +335,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.2.201409121644</version>
+				<version>0.8.2</version>
 				<configuration>
 					<fileSets>
 						<fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">


### PR DESCRIPTION
This PR makes it possible to build and test Juneau on JDK 11. It does not change the source target from Java 8.

There are a few categories of changes here.
1. JaCoCo is updated to 0.8.2. The newer version is required for Java 11
2. JEE modules are explicitly added as dependencies. Starting with JDK 9, `javax.xml.bind` and `javax.activation` packages are no longer included in the Java SE, so they need to be explicitly added.
3. `URLClassLoader::findResource` is removed in favor of `Class::getResource`. With Java 9+, you can no longer cast a `ClassLoader` to a `URLClassLoader`.
4. Explicit imports from `java.beans.*`: Java 9+ introduces some new class names in the `java.beans` package which conflict with other imports (e.g. `o.a.j.annotation.BeanProperty`). By avoiding the star import from the `java.beans` package, one can avoid the ambiguous Class names.
5. The DateFormatter defaults have changed to use CLDR by default (see [JEP 252](https://openjdk.java.net/jeps/252)). In practice, this means that many of the locale-aware tests in `juneau-core-tests` fail because they include a comma or other character between the date and the time part of the resulting String. By setting a system property in the surefire plugin, one can ensure that the effective value of `java.locale.providers` is the same across JDK versions