### PR TITLE
Add Automatic-Module-Name metadata

### DIFF
--- a/juneau-core/juneau-config/pom.xml
+++ b/juneau-core/juneau-config/pom.xml
@@ -56,6 +56,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.config</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-core/juneau-core-test/pom.xml
+++ b/juneau-core/juneau-core-test/pom.xml
@@ -84,6 +84,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.core.test</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-core/juneau-dto/pom.xml
+++ b/juneau-core/juneau-dto/pom.xml
@@ -55,6 +55,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.dto</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-core/juneau-marshall-rdf/pom.xml
+++ b/juneau-core/juneau-marshall-rdf/pom.xml
@@ -60,6 +60,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.marshall.rdf</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-core/juneau-marshall/pom.xml
+++ b/juneau-core/juneau-marshall/pom.xml
@@ -50,6 +50,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.marshall</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-core/juneau-svl/pom.xml
+++ b/juneau-core/juneau-svl/pom.xml
@@ -51,6 +51,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.svl</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-doc/pom.xml
+++ b/juneau-doc/pom.xml
@@ -108,6 +108,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.doc</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-rest/juneau-rest-client/pom.xml
+++ b/juneau-rest/juneau-rest-client/pom.xml
@@ -93,6 +93,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.rest.client</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-rest/juneau-rest-server-jaxrs/pom.xml
+++ b/juneau-rest/juneau-rest-server-jaxrs/pom.xml
@@ -83,6 +83,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.rest.server.jaxrs</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-rest/juneau-rest-server-rdf/pom.xml
+++ b/juneau-rest/juneau-rest-server-rdf/pom.xml
@@ -86,6 +86,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.rest.server.rdf</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-rest/juneau-rest-server-springboot/pom.xml
+++ b/juneau-rest/juneau-rest-server-springboot/pom.xml
@@ -77,6 +77,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.rest.server.springboot</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/juneau-rest/juneau-rest-server/pom.xml
+++ b/juneau-rest/juneau-rest-server/pom.xml
@@ -102,6 +102,11 @@
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.2.0</version>
 				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Automatic-Module-Name>org.apache.juneau.rest.server</Automatic-Module-Name>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Resolves JUNEAU-96

For these metadata, I simply used the existing `artifactId`, converting hyphens to periods. The advantage with that approach is that it is consistent, but it does result in some long names. For example: `org.apache.juneau.rest.server.springboot`. There may be a better naming convention, but I do like the simplicity of doing it like this.