### PR TITLE
JUNEAU-129: Use Locale.ROOT during test

### DIFF
--- a/juneau-core/juneau-core-utest/src/test/java/org/apache/juneau/transforms/LocalizedDatesTest.java
+++ b/juneau-core/juneau-core-utest/src/test/java/org/apache/juneau/transforms/LocalizedDatesTest.java
@@ -35,16 +35,21 @@ public class LocalizedDatesTest {
 	}
 
 	private static TimeZone prevTimeZone;
+	private static Locale prevLocale;
 
 	@BeforeClass
 	public static void before() {
 		prevTimeZone = TimeZone.getDefault();
 		TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+		prevLocale = Locale.getDefault();
+		Locale.setDefault(Locale.ROOT);
+
 	}
 
 	@AfterClass
 	public static void after() {
 		TimeZone.setDefault(prevTimeZone);
+		Locale.setDefault(prevLocale);
 	}
 
 


### PR DESCRIPTION
This fixes [JUNEAU-129](https://issues.apache.org/jira/browse/JUNEAU-129) by ensuring `Locale.ROOT` is used for the test.

This means the part of the test using `null` locale will get predictable results. However in deployment the `null` options will naturally give varying effects depending on the locale at JVM startup.