### PR TITLE
Add org.apache.juneau.PropertyStoreBuilder.clearCache().

### DIFF
--- a/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/PropertyStoreBuilder.java
+++ b/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/PropertyStoreBuilder.java
@@ -75,6 +75,13 @@ public class PropertyStoreBuilder {
 	}
 
 	/**
+	 * Clears the PropertyStore cache.
+	 */
+	public void clearCache() {
+		CACHE.clear();
+	}
+	
+	/**
 	 * Copies all the values in the specified property store into this builder.
 	 *
 	 * @param copyFrom The property store to copy the values from.


### PR DESCRIPTION
Add `PropertyStore.clearCache()` which I currently implement using reflection and call from our company's test rules to clear this cache when we bring Juneau up and down a ton of times from the same JVM during tests in builds. 

This works around errors like the following for us:
```
error	28-Apr-2020 15:40:37	java.lang.RuntimeException: org.apache.juneau.FormattedRuntimeException: Could not instantiate class org.apache.juneau.serializer.Serializer
error	28-Apr-2020 15:40:37		at org.apache.juneau.rest.RestContextBuilder.build(RestContextBuilder.java:262)
error	28-Apr-2020 15:40:37		at org.apache.juneau.rest.RestServlet.init(RestServlet.java:53)
error	28-Apr-2020 15:40:37		at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:602)
error	28-Apr-2020 15:40:37		at org.eclipse.jetty.servlet.ServletHolder.getServlet(ServletHolder.java:473)
<SNIP/>
error	28-Apr-2020 15:40:37		at java.base/java.lang.Thread.run(Thread.java:834)
error	28-Apr-2020 15:40:37	Caused by: org.apache.juneau.FormattedRuntimeException: Could not instantiate class org.apache.juneau.serializer.Serializer
error	28-Apr-2020 15:40:37		at org.apache.juneau.internal.ClassUtils.newInstanceFromOuter(ClassUtils.java:1890)
error	28-Apr-2020 15:40:37		at org.apache.juneau.PropertyStore$Property.asInstanceArray(PropertyStore.java:876)
error	28-Apr-2020 15:40:37		at org.apache.juneau.PropertyStore.getInstanceArrayProperty(PropertyStore.java:590)
error	28-Apr-2020 15:40:37		at org.apache.juneau.PropertyStore.getInstanceArrayProperty(PropertyStore.java:569)
error	28-Apr-2020 15:40:37		at org.apache.juneau.Context.getInstanceArrayProperty(Context.java:403)
error	28-Apr-2020 15:40:37		at org.apache.juneau.rest.RestContext.<init>(RestContext.java:3162)
error	28-Apr-2020 15:40:37		at org.apache.juneau.rest.RestContextBuilder.build(RestContextBuilder.java:258)
error	28-Apr-2020 15:40:37		... 10 more
error	28-Apr-2020 15:40:37	Caused by: java.lang.reflect.InvocationTargetException
error	28-Apr-2020 15:40:37		at jdk.internal.reflect.GeneratedConstructorAccessor96.newInstance(Unknown Source)
error	28-Apr-2020 15:40:37		at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
error	28-Apr-2020 15:40:37		at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
error	28-Apr-2020 15:40:37		at org.apache.juneau.internal.ClassUtils.newInstanceFromOuter(ClassUtils.java:1885)
error	28-Apr-2020 15:40:37		... 16 more
error	28-Apr-2020 15:40:37	Caused by: java.lang.RuntimeException: Property store mismatch!  This shouldn't happen.
error	28-Apr-2020 15:40:37		at org.apache.juneau.PropertyStoreBuilder.build(PropertyStoreBuilder.java:70)
error	28-Apr-2020 15:40:37		at org.apache.juneau.oapi.OpenApiSerializer.<init>(OpenApiSerializer.java:72)
error	28-Apr-2020 15:40:37		at org.apache.juneau.oapi.OpenApiSerializer.<init>(OpenApiSerializer.java:85)
error	28-Apr-2020 15:40:37		... 20 more

```