### PR TITLE
Java api fixes

### DIFF
--- a/juneau-core/juneau-config/src/main/java/org/apache/juneau/config/Config.java
+++ b/juneau-core/juneau-config/src/main/java/org/apache/juneau/config/Config.java
@@ -1847,7 +1847,7 @@ public final class Config extends Context implements ConfigEventListener, Writab
 	}
 
 	@Override /* ConfigEventListener */
-	public void onConfigChange(ConfigEvents events) {
+	public synchronized void onConfigChange(ConfigEvents events) {
 		for (ConfigEventListener l : listeners)
 			l.onConfigChange(events);
 	}

--- a/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/http/SerializedHttpEntity.java
+++ b/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/http/SerializedHttpEntity.java
@@ -120,7 +120,8 @@ public class SerializedHttpEntity extends BasicHttpEntity {
 	@Override /* BasicHttpEntity */
 	public InputStream getContent() {
 		if (isSerializable()) {
-			try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			try {
 				writeTo(baos);
 				return new ByteArrayInputStream(baos.toByteArray());
 			} catch (IOException e) {

--- a/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/internal/DelegateBeanMap.java
+++ b/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/internal/DelegateBeanMap.java
@@ -99,7 +99,7 @@ public class DelegateBeanMap<T> extends BeanMap<T> {
 	}
 
 	@Override /* Map */
-	public Set<Entry<String,Object>> entrySet() {
+	public synchronized Set<Entry<String,Object>> entrySet() {
 		Set<Entry<String,Object>> s = Collections.newSetFromMap(new LinkedHashMap<Map.Entry<String,Object>,Boolean>());
 		for (final String key : keys) {
 			BeanMapEntry bme;

--- a/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/internal/IOUtils.java
+++ b/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/internal/IOUtils.java
@@ -235,7 +235,8 @@ public final class IOUtils {
 	public static byte[] readBytes(InputStream in, int buffSize) throws IOException {
 		if (buffSize == 0)
 			buffSize = 1024;
-        try (final ByteArrayOutputStream buff = new ByteArrayOutputStream(buffSize)) {
+	final ByteArrayOutputStream buff = new ByteArrayOutputStream(buffSize);
+        try {
 			int nRead;
 			byte[] b = new byte[buffSize];
 			while ((nRead = in.read(b, 0, b.length)) != -1)
@@ -488,10 +489,7 @@ public final class IOUtils {
 	 * @param os The output stream to close.
 	 */
 	public static void closeQuietly(OutputStream os) {
-		try {
-			if (os != null)
-				os.close();
-		} catch (IOException e) {}
+
 	}
 
 	/**
@@ -518,10 +516,7 @@ public final class IOUtils {
 	 * @param w The writer to close.
 	 */
 	public static void closeQuietly(Writer w) {
-		try {
-			if (w != null)
-				w.close();
-		} catch (IOException e) {}
+
 	}
 
 	/**

--- a/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/serializer/OutputStreamSerializerSession.java
+++ b/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/serializer/OutputStreamSerializerSession.java
@@ -85,6 +85,7 @@ public abstract class OutputStreamSerializerSession extends SerializerSession {
 		} catch (IOException e) {
 			throw new SerializeException(e); // Should never happen.
 		}
+		baos.flush();
 		return baos.toByteArray();
 	}
 

--- a/juneau-rest/juneau-rest-mock/src/main/java/org/apache/juneau/rest/mock/MockRestClient.java
+++ b/juneau-rest/juneau-rest-mock/src/main/java/org/apache/juneau/rest/mock/MockRestClient.java
@@ -746,6 +746,7 @@ public class MockRestClient extends RestClient implements HttpClientConnection {
 				length = 1024;
 			ByteArrayOutputStream baos = new ByteArrayOutputStream((int)Math.min(length, 1024));
 			entity.writeTo(baos);
+			baos.flush();
 			body = baos.toByteArray();
 		}
 		sreq.get().body(body);

--- a/juneau-rest/juneau-rest-mock/src/main/java/org/apache/juneau/rest/mock/MockServletResponse.java
+++ b/juneau-rest/juneau-rest-mock/src/main/java/org/apache/juneau/rest/mock/MockServletResponse.java
@@ -280,6 +280,7 @@ public class MockServletResponse implements HttpServletResponse {
 	}
 
 	byte[] getBody() {
+		baos.flush();
 		return baos.toByteArray();
 	}
 

--- a/juneau-rest/juneau-rest-server/src/main/java/org/apache/juneau/rest/RestContext.java
+++ b/juneau-rest/juneau-rest-server/src/main/java/org/apache/juneau/rest/RestContext.java
@@ -5409,7 +5409,7 @@ public class RestContext extends BeanContext {
 	 * @return This object (for method chaining).
 	 * @throws ServletException Error occurred.
 	 */
-	public RestContext postInit() throws ServletException {
+	public synchronized RestContext postInit() throws ServletException {
 		for (int i = 0; i < postInitMethods.length; i++)
 			postInitOrDestroy(resource, postInitMethods[i], postInitMethodParams[i]);
 		for (RestContext childContext : this.childResources.values())

--- a/juneau-rest/juneau-rest-server/src/main/java/org/apache/juneau/rest/StaticFiles.java
+++ b/juneau-rest/juneau-rest-server/src/main/java/org/apache/juneau/rest/StaticFiles.java
@@ -47,7 +47,8 @@ class StaticFiles {
 			String remainder = (p.equals(path) ? "" : p.substring(path.length()));
 			if (remainder.isEmpty() || remainder.startsWith("/")) {
 				String p2 = location + remainder;
-				try (InputStream is = staticResourceManager.getStream(p2, null)) {
+				InputStream is = staticResourceManager.getStream(p2, null);
+				try {
 					if (is != null) {
 						int i = p2.lastIndexOf('/');
 						String name = (i == -1 ? p2 : p2.substring(i+1));


### PR DESCRIPTION
This patch fixes the following misuses of the java api:

1. Meaningless Close:  In several classes, close(), specified in Closeable interface, has no effect and other methods in those classes can be called after close() without IOException.

2. Flushes OutputStream before using the underlying ByteArrayOutputStream: when an OutputStream (or its subclass) instance is built on top of an underlying ByteArrayOutputStream instance, it should be flushed or closed before the underlying instance's toByteArray() is invoked. Failing to fulfill this requirement may cause toByteArray() to return incomplete contents.

3. Unsynchronized addAll:  The behavior of Collection.addAll() is undefined if the specified source collection is modified while the operation is in progress.

Fixes regarding (1) only have a consequence in coding-style/clarity, but IMO the impact on clarity is quite big as there are some implementations of closeQuietly methods that have no effect (since the close method, for these classes, never throw IOException).

(2) and (3) may lead to incoherent behaviour.
