### PR TITLE
Update JettyLogger to run on Jetty 9 (9.4.49) and 10 (10.0.12)

### DIFF
--- a/juneau-core/juneau-assertions/pom.xml
+++ b/juneau-core/juneau-assertions/pom.xml
@@ -39,9 +39,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -49,7 +46,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-core/juneau-common/pom.xml
+++ b/juneau-core/juneau-common/pom.xml
@@ -38,9 +38,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -48,7 +45,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-core/juneau-config/pom.xml
+++ b/juneau-core/juneau-config/pom.xml
@@ -39,9 +39,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -49,7 +46,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-core/juneau-dto/pom.xml
+++ b/juneau-core/juneau-dto/pom.xml
@@ -43,9 +43,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -53,7 +50,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-core/juneau-marshall-rdf/pom.xml
+++ b/juneau-core/juneau-marshall-rdf/pom.xml
@@ -48,9 +48,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -58,7 +55,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-core/juneau-marshall/pom.xml
+++ b/juneau-core/juneau-marshall/pom.xml
@@ -31,9 +31,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -57,7 +54,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-doc/pom.xml
+++ b/juneau-doc/pom.xml
@@ -32,9 +32,6 @@
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-
 		<!-- Note:  If you want to build the docs, you have to update the following location for tools.jar -->
 		<toolsjar>/Library/Java/JavaVirtualMachines/jdk1.8.0_162.jdk/Contents/Home/lib/tools.jar</toolsjar>
 	</properties>
@@ -94,7 +91,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-examples/juneau-examples-core/build-overlay/pom.xml
+++ b/juneau-examples/juneau-examples-core/build-overlay/pom.xml
@@ -26,9 +26,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/juneau-examples/juneau-examples-core/pom.xml
+++ b/juneau-examples/juneau-examples-core/pom.xml
@@ -30,9 +30,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/juneau-examples/juneau-examples-rest-jetty-ftest/pom.xml
+++ b/juneau-examples/juneau-examples-rest-jetty-ftest/pom.xml
@@ -32,7 +32,6 @@
 
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-
 	</properties>
 
 

--- a/juneau-examples/juneau-examples-rest-springboot/pom.xml
+++ b/juneau-examples/juneau-examples-rest-springboot/pom.xml
@@ -33,10 +33,6 @@
 
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-
-		<!-- Java 8 required because Jetty requires it. -->
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/juneau-microservice/juneau-microservice-core/pom.xml
+++ b/juneau-microservice/juneau-microservice-core/pom.xml
@@ -30,10 +30,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<!-- Java 8 required because Jetty requires it. -->
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/juneau-microservice/juneau-microservice-ftest/pom.xml
+++ b/juneau-microservice/juneau-microservice-ftest/pom.xml
@@ -29,10 +29,6 @@
 
 	<properties>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<!-- Java 8 required because Jetty requires it. -->
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/juneau-microservice/juneau-microservice-jetty/pom.xml
+++ b/juneau-microservice/juneau-microservice-jetty/pom.xml
@@ -30,10 +30,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<!-- Java 8 required because Jetty requires it. -->
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/juneau-microservice/juneau-microservice-jetty/src/main/java/org/apache/juneau/microservice/jetty/JettyLogger.java
+++ b/juneau-microservice/juneau-microservice-jetty/src/main/java/org/apache/juneau/microservice/jetty/JettyLogger.java
@@ -12,12 +12,15 @@
 // ***************************************************************************************************************************
 package org.apache.juneau.microservice.jetty;
 
-import static java.util.logging.Level.*;
-import static org.apache.juneau.internal.SystemEnv.*;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
+import static org.apache.juneau.internal.SystemEnv.env;
 
-import java.util.logging.*;
-
-import org.eclipse.jetty.util.log.AbstractLogger;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 /**
  * Implementation of Jetty {@link Logger} based on {@link java.util.logging.Logger}.
@@ -41,7 +44,7 @@ import org.eclipse.jetty.util.log.AbstractLogger;
  * 	<li class='extlink'>{@source}
  * </ul>
  */
-public class JettyLogger extends AbstractLogger {
+public class JettyLogger implements org.eclipse.jetty.util.log.Logger {
 	private static final boolean SHOW_SOURCE = env("org.eclipse.jetty.util.log.SOURCE", env("org.eclipse.jetty.util.log.javautil.SOURCE", true));
 
 	private Level configuredLevel;
@@ -66,6 +69,11 @@ public class JettyLogger extends AbstractLogger {
 		logger = Logger.getLogger(name);
 		configuredLevel = logger.getLevel();
 	}
+
+    @Override
+    public org.eclipse.jetty.util.log.Logger getLogger(String name) {
+        return new JettyLogger(name);
+    }
 
 	@Override
 	public String getName() {
@@ -148,14 +156,9 @@ public class JettyLogger extends AbstractLogger {
 	}
 
 	@Override
-	protected org.eclipse.jetty.util.log.Logger newLogger(String fullname) {
-		return new JettyLogger(fullname);
-	}
-
-	@Override
 	public void ignore(Throwable ignored) {
 		if (isLoggable(FINEST))
-			log(FINEST, org.eclipse.jetty.util.log.Log.IGNORED, ignored);
+			log(FINEST, "IGNORED EXCEPTION ", ignored);
 	}
 
 	private static String format(String msg, Object... args) {
@@ -200,4 +203,5 @@ public class JettyLogger extends AbstractLogger {
 	private boolean isLoggable(Level level) {
 		return logger.isLoggable(level);
 	}
+
 }

--- a/juneau-rest/juneau-rest-client/pom.xml
+++ b/juneau-rest/juneau-rest-client/pom.xml
@@ -51,9 +51,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -61,7 +58,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-rest/juneau-rest-common/pom.xml
+++ b/juneau-rest/juneau-rest-common/pom.xml
@@ -48,9 +48,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -58,7 +55,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-rest/juneau-rest-mock/pom.xml
+++ b/juneau-rest/juneau-rest-mock/pom.xml
@@ -60,9 +60,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -70,7 +67,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-rest/juneau-rest-server-rdf/pom.xml
+++ b/juneau-rest/juneau-rest-server-rdf/pom.xml
@@ -48,9 +48,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -71,7 +68,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-rest/juneau-rest-server-springboot/pom.xml
+++ b/juneau-rest/juneau-rest-server-springboot/pom.xml
@@ -52,9 +52,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -79,7 +76,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-rest/juneau-rest-server/pom.xml
+++ b/juneau-rest/juneau-rest-server/pom.xml
@@ -69,9 +69,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -92,7 +89,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-utest-utils/pom.xml
+++ b/juneau-utest-utils/pom.xml
@@ -48,9 +48,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -58,7 +55,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/juneau-utest/pom.xml
+++ b/juneau-utest/pom.xml
@@ -77,9 +77,6 @@
 	<properties>
 		<!-- Skip javadoc generation since we generate them in the aggregate pom -->
 		<maven.javadoc.skip>true</maven.javadoc.skip>
-		
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<build>
@@ -87,7 +84,6 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>3.2.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
 		<groupId>org.apache</groupId>
 		<artifactId>apache</artifactId>
-		<version>21</version>
+		<version>27</version>
 	</parent>
 
 	<properties>
@@ -51,6 +51,7 @@
 		<springboot.version>2.7.4</springboot.version>
 		<xml.apis.version>1.4.01</xml.apis.version>
 		<javadoc.executable />
+		<javadoc.plugin.version>3.4.1</javadoc.plugin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -73,12 +74,6 @@
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
-				<groupId>javax.xml.bind</groupId>
-				<artifactId>jaxb-api</artifactId>
-				<version>${jaxb.version}</version>
-				<scope>provided</scope>
-			</dependency>
-			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
 				<version>${httpclient.version}</version>
@@ -87,6 +82,12 @@
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpcore</artifactId>
 				<version>${httpcore.version}</version>
+			</dependency>
+			<dependency>
+				<!-- Java 11 -->
+				<groupId>javax.xml.bind</groupId>
+				<artifactId>jaxb-api</artifactId>
+				<version>${jaxb.version}</version>
 			</dependency>
 			<dependency>
 				<!-- Java 11 -->
@@ -211,7 +212,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>${javadoc.plugin.version}</version>
 					<configuration>
 						<doclint>missing,reference,syntax</doclint>
 						<sourcetab>3</sourcetab>
@@ -288,12 +289,19 @@
 
 				<plugin>
 					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.10.1</version>
 					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
+						<source>${maven.compiler.source}</source>
+						<target>${maven.compiler.target}</target>
 						<compilerArgument>-parameters</compilerArgument>
 						<testCompilerArgument>-parameters</testCompilerArgument>
 					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>5.1.8</version>
 				</plugin>
 
 				<plugin>
@@ -330,7 +338,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.4</version>
+				<version>${javadoc.plugin.version}</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -340,7 +348,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>2.18</version>
+				<version>2.22.2</version>
 				<configuration>
 					<aggregate>true</aggregate>
 				</configuration>
@@ -348,7 +356,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.2</version>
+				<version>0.8.8</version>
 				<configuration>
 					<excludes>
 						<exclude>**/doc/**/*</exclude>


### PR DESCRIPTION
* Make POMs easier to modify for Java 11 and Jetty 10 testing
* Let modules inherit Maven compiler settings from the parent POM
* Define and reuse property javadoc.plugin.version
* Make JAXB another Java 11 style dependency like javax.activation
* Define maven-bundle-plugin in the parent POM
* Bump maven-surefire-report-plugin from 2.18 to 2.22.2
* Bump jacoco-maven-plugin from 0.8.2 to 0.8.8
* Bump apache parent POM from 21 to 27