### PR TITLE
Replace deprecated Jetty NCSARequestLog with CustomRequestLog

### DIFF
--- a/juneau-examples/juneau-examples-rest-jetty/src/main/resources/jetty.xml
+++ b/juneau-examples/juneau-examples-rest-jetty/src/main/resources/jetty.xml
@@ -53,13 +53,21 @@
 	</Set>
 
 	<Set name="requestLog">
-		<New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
-			<Set name="filename"><Property name="jetty.logs" default="$S{juneau.logDir,logs}"/>/jetty-requests.log</Set>
-			<Set name="filenameDateFormat">yyyy_MM_dd</Set>
-			<Set name="LogTimeZone">GMT</Set>
-			<Set name="retainDays">90</Set>
-			<Set name="append">false</Set>
-			<Set name="LogLatency">true</Set>
+		<New id="RequestLogImpl" class="org.eclipse.jetty.server.CustomRequestLog">
+			<!-- Param 0: org.eclipse.jetty.server.RequestLogWriter -->
+			<Arg>
+				<New class="org.eclipse.jetty.server.RequestLogWriter">
+					<Set name="append">false</Set>
+					<Set name="filename"><Property name="jetty.logs" default="$S{Logging/logDir,logs}"/>/jetty-requests.log</Set>
+					<Set name="filenameDateFormat">yyyy_MM_dd</Set>
+					<Set name="retainDays">90</Set>
+					<Set name="timeZone">GMT</Set>
+				</New>
+			</Arg>
+			<!-- Param 1: String -->
+			<Arg>
+				<Get class="org.eclipse.jetty.server.CustomRequestLog" name="EXTENDED_NCSA_FORMAT" />
+			</Arg>      
 		</New>
 	</Set>
 

--- a/juneau-microservice/juneau-microservice-ftest/files/jetty.xml
+++ b/juneau-microservice/juneau-microservice-ftest/files/jetty.xml
@@ -53,13 +53,21 @@
 	</Set>
 
 	<Set name="requestLog">
-		<New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
-			<Set name="filename"><Property name="jetty.logs" default="$C{Logging/logDir,logs}"/>/jetty-requests.log</Set>
-			<Set name="filenameDateFormat">yyyy_MM_dd</Set>
-			<Set name="LogTimeZone">GMT</Set>
-			<Set name="retainDays">90</Set>
-			<Set name="append">false</Set>
-			<Set name="LogLatency">true</Set>
+		<New id="RequestLogImpl" class="org.eclipse.jetty.server.CustomRequestLog">
+			<!-- Param 0: org.eclipse.jetty.server.RequestLogWriter -->
+			<Arg>
+				<New class="org.eclipse.jetty.server.RequestLogWriter">
+					<Set name="append">false</Set>
+					<Set name="filename"><Property name="jetty.logs" default="$C{Logging/logDir,logs}" />/jetty-requests.log</Set>
+					<Set name="filenameDateFormat">yyyy_MM_dd</Set>
+					<Set name="retainDays">90</Set>
+					<Set name="timeZone">GMT</Set>
+				</New>
+			</Arg>
+			<!-- Param 1: String -->
+			<Arg>
+				<Get class="org.eclipse.jetty.server.CustomRequestLog" name="EXTENDED_NCSA_FORMAT" />
+			</Arg>      
 		</New>
 	</Set>
 

--- a/juneau-microservice/juneau-my-jetty-microservice/src/main/resources/jetty.xml
+++ b/juneau-microservice/juneau-my-jetty-microservice/src/main/resources/jetty.xml
@@ -58,13 +58,21 @@
 	</Set>
 
 	<Set name="requestLog">
-		<New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
-			<Set name="filename"><Property name="jetty.logs" default="$C{Logging/logDir,logs}"/>/jetty-requests.log</Set>
-			<Set name="filenameDateFormat">yyyy_MM_dd</Set>
-			<Set name="LogTimeZone">GMT</Set>
-			<Set name="retainDays">90</Set>
-			<Set name="append">false</Set>
-			<Set name="LogLatency">true</Set>
+		<New id="RequestLogImpl" class="org.eclipse.jetty.server.CustomRequestLog">
+			<!-- Param 0: org.eclipse.jetty.server.RequestLogWriter -->
+			<Arg>
+				<New class="org.eclipse.jetty.server.RequestLogWriter">
+					<Set name="append">false</Set>
+					<Set name="filename"><Property name="jetty.logs" default="$C{Logging/logDir,logs}" />/jetty-requests.log</Set>
+					<Set name="filenameDateFormat">yyyy_MM_dd</Set>
+					<Set name="retainDays">90</Set>
+					<Set name="timeZone">GMT</Set>
+				</New>
+			</Arg>
+			<!-- Param 1: String -->
+			<Arg>
+				<Get class="org.eclipse.jetty.server.CustomRequestLog" name="EXTENDED_NCSA_FORMAT" />
+			</Arg>      
 		</New>
 	</Set>
 

--- a/juneau-sc/juneau-sc-server/src/main/resources/jetty.xml
+++ b/juneau-sc/juneau-sc-server/src/main/resources/jetty.xml
@@ -53,13 +53,21 @@
 	</Set>
 
 	<Set name="requestLog">
-		<New id="RequestLogImpl" class="org.eclipse.jetty.server.NCSARequestLog">
-			<Set name="filename"><Property name="jetty.logs" default="$C{Logging/logDir,logs}"/>/jetty-requests.log</Set>
-			<Set name="filenameDateFormat">yyyy_MM_dd</Set>
-			<Set name="LogTimeZone">GMT</Set>
-			<Set name="retainDays">90</Set>
-			<Set name="append">false</Set>
-			<Set name="LogLatency">true</Set>
+		<New id="RequestLogImpl" class="org.eclipse.jetty.server.CustomRequestLog">
+			<!-- Param 0: org.eclipse.jetty.server.RequestLogWriter -->
+			<Arg>
+				<New class="org.eclipse.jetty.server.RequestLogWriter">
+					<Set name="append">false</Set>
+					<Set name="filename"><Property name="jetty.logs" default="$C{Logging/logDir,logs}" />/jetty-requests.log</Set>
+					<Set name="filenameDateFormat">yyyy_MM_dd</Set>
+					<Set name="retainDays">90</Set>
+					<Set name="timeZone">GMT</Set>
+				</New>
+			</Arg>
+			<!-- Param 1: String -->
+			<Arg>
+				<Get class="org.eclipse.jetty.server.CustomRequestLog" name="EXTENDED_NCSA_FORMAT" />
+			</Arg>      
 		</New>
 	</Set>
 


### PR DESCRIPTION
Replace deprecated org.eclipse.jetty.server.NCSARequestLog with org.eclipse.jetty.server.CustomRequestLog

NCSARequestLog is deprecated in Jetty 9 has removed in Jetty 10