### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,18 +1,18 @@
 notifications:
-  commits:      commits@juneau.apache.org
-  issues:       dev@juneau.apache.org
+  commits: commits@juneau.apache.org
+  issues: dev@juneau.apache.org
   pullrequests: dev@juneau.apache.org
   jira_options: link label worklog
-  jobs:         dev@juneau.apache.org
-  discussions:  dev@juneau.apache.org
+  jobs: dev@juneau.apache.org
+  discussions: dev@juneau.apache.org
 
 # Configure staging website (safe testing)
 staging:
-  profile: ~
+  profile:
   whoami: asf-staging
 
 publish:
-  whoami: asf-site  
+  whoami: asf-site
 
 github:
   description: "Apache Juneau"
@@ -44,3 +44,16 @@ github:
     issues: true
     projects: true
     discussions: true
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
