### PR TITLE
Use Apache Commons Secure XML

### DIFF
--- a/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/marshall/xml/XmlReader.java
+++ b/juneau-core/juneau-marshall/src/main/java/org/apache/juneau/marshall/xml/XmlReader.java
@@ -26,6 +26,7 @@ import javax.xml.namespace.*;
 import javax.xml.stream.*;
 import javax.xml.stream.util.*;
 
+import org.apache.commons.xml.secure.SecureXMLInputFactory;
 import org.apache.juneau.marshall.parser.*;
 
 /**
@@ -66,21 +67,9 @@ public class XmlReader implements XMLStreamReader, Positionable {
 		this.pipe = pipe;
 		try {
 			Reader r = pipe.getBufferedReader();
-			var factory = XMLInputFactory.newInstance();
+			var factory = SecureXMLInputFactory.newInstance();
 			factory.setProperty(XMLInputFactory.IS_VALIDATING, validating);
 			factory.setProperty(XMLInputFactory.IS_COALESCING, true);
-			factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
-			factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-			// Disable DTD processing unconditionally.  DTD constructs are not needed for data binding, and
-			// keeping them off — regardless of the validating flag — bounds document/entity handling so a
-			// declared internal DTD cannot drive runaway entity expansion.
-			factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-			// Belt-and-suspenders: forbid resolving any external DTD/schema on factories that honor these
-			// properties, in case a StAX implementation handles external-entity support inconsistently.
-			if (factory.isPropertySupported(XMLConstants.ACCESS_EXTERNAL_DTD))
-				factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			if (factory.isPropertySupported(XMLConstants.ACCESS_EXTERNAL_SCHEMA))
-				factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 			if (factory.isPropertySupported(XMLInputFactory.REPORTER) && nn(reporter))
 				factory.setProperty(XMLInputFactory.REPORTER, reporter);
 			if (factory.isPropertySupported(XMLInputFactory.RESOLVER) && nn(resolver))

--- a/juneau-core/juneau-marshall/src/test/java/org/apache/juneau/marshall/xml/XmlSecurity_Test.java
+++ b/juneau-core/juneau-marshall/src/test/java/org/apache/juneau/marshall/xml/XmlSecurity_Test.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.juneau.marshall.xml;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.*;
+import java.nio.charset.*;
+import java.nio.file.*;
+import java.util.concurrent.atomic.*;
+
+import javax.xml.stream.*;
+
+import org.apache.juneau.*;
+import org.apache.juneau.marshall.parser.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import com.sun.net.httpserver.*;
+
+/**
+ * Exercises external-resource and expansion attacks through Juneau's configured StAX reader.
+ */
+class XmlSecurity_Test extends TestBase {
+
+	private HttpServer server;
+	private final AtomicInteger requests = new AtomicInteger();
+	private String external;
+
+	@BeforeEach void startServer() throws Exception {
+		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/external", exchange -> {
+			requests.incrementAndGet();
+			var body = "<!ENTITY injected 'FETCHED'>".getBytes(StandardCharsets.UTF_8);
+			exchange.sendResponseHeaders(200, body.length);
+			try (var stream = exchange.getResponseBody()) {
+				stream.write(body);
+			}
+		});
+		server.start();
+		external = "http://127.0.0.1:" + server.getAddress().getPort() + "/external";
+	}
+
+	@AfterEach void stopServer() {
+		if (server != null)
+			server.stop(0);
+	}
+
+	private static String externalDocument(String vector, String uri) {
+		return switch (vector) {
+			case "general" -> "<!DOCTYPE A [<!ENTITY ext SYSTEM '" + uri + "'>]><A>&ext;</A>";
+			case "parameter" -> "<!DOCTYPE A [<!ENTITY % ext SYSTEM '" + uri + "'>%ext;]><A>safe</A>";
+			case "systemDtd" -> "<!DOCTYPE A SYSTEM '" + uri + "'><A>safe</A>";
+			case "publicDtd" -> "<!DOCTYPE A PUBLIC '-//Juneau//DTD XXE Test//EN' '" + uri + "'><A>safe</A>";
+			default -> throw new IllegalArgumentException(vector);
+		};
+	}
+
+	private static String expansionDocument() {
+		// 100,000 leaf expansions exceed the JDK 17/21 default count, but stay small if protection regresses.
+		var dtd = new StringBuilder("<!DOCTYPE A [<!ENTITY e0 'x'>");
+		for (int i = 1; i <= 5; i++)
+			dtd.append("<!ENTITY e").append(i).append(" '").append(("&e" + (i - 1) + ";").repeat(10)).append("'>");
+		return dtd.append("]><A>&e5;</A>").toString();
+	}
+
+	/**
+	 * Declines every request, leaving the secure fallback responsible for blocking access.
+	 */
+	public static class DecliningResolver implements XMLResolver {
+		@Override public Object resolveEntity(String publicId, String systemId, String baseUri, String namespace) {
+			return null;
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"general", "parameter", "systemDtd", "publicDtd"})
+	void externalReferencesNeverFetch(String vector) throws Exception {
+		for (var parser : new XmlParser[] {XmlParser.DEFAULT, XmlParser.create().resolver(DecliningResolver.class).build()}) {
+			assertEquals("safe", parser.read("<A>safe</A>", String.class));
+			try {
+				var result = parser.read(externalDocument(vector, external), String.class);
+				assertFalse(result != null && result.contains("FETCHED"));
+			} catch (ParseException expected) {
+				// Rejection and empty resolution are both safe, but neither may fetch the resource first.
+			}
+			assertEquals(0, requests.get(), vector + " fetched an external resource");
+		}
+	}
+
+	@Test void fileEntityDoesNotDiscloseContents(@TempDir Path directory) throws Exception {
+		var secret = directory.resolve("secret.txt");
+		Files.writeString(secret, "PRIVATE_FILE_MARKER");
+		assertEquals("safe", XmlParser.DEFAULT.read("<A>safe</A>", String.class));
+		try {
+			var result = XmlParser.DEFAULT.read(externalDocument("general", secret.toUri().toString()), String.class);
+			assertFalse(result != null && result.contains("PRIVATE_FILE_MARKER"));
+		} catch (ParseException expected) {
+			for (Throwable cause = expected; cause != null; cause = cause.getCause())
+				assertFalse(cause.toString().contains("PRIVATE_FILE_MARKER"));
+		}
+	}
+
+	@Test
+	@Timeout(10)
+	void exponentialEntityExpansionIsRejected() {
+		assertThrows(ParseException.class, () -> XmlParser.DEFAULT.read(expansionDocument(), String.class));
+	}
+}

--- a/juneau-core/juneau-marshall/src/test/java/org/apache/juneau/marshall/xml/XmlUtils_Test.java
+++ b/juneau-core/juneau-marshall/src/test/java/org/apache/juneau/marshall/xml/XmlUtils_Test.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.*;
 import java.util.*;
 
+import org.apache.commons.xml.secure.SecureXMLInputFactory;
 import org.apache.juneau.*;
 import org.junit.jupiter.api.*;
 
@@ -426,7 +427,7 @@ class XmlUtils_Test extends TestBase {
 	@Test void h01_toReadableEvent() throws Exception {
 		// Use a real XMLStreamReader to walk through events.
 		var xml = "<root><child>text</child></root>";
-		var f = javax.xml.stream.XMLInputFactory.newInstance();
+		var f = SecureXMLInputFactory.newInstance();
 		try (var sr = new StringReader(xml)) {
 			var r = f.createXMLStreamReader(sr);
 			r.next(); // START_ELEMENT (root)
@@ -446,7 +447,7 @@ class XmlUtils_Test extends TestBase {
 	// PROCESSING_INSTRUCTION (event type 3)
 	@Test void h02_toReadableEvent_processingInstruction() throws Exception {
 		var xml = "<?pi target?><root/>";
-		var f = javax.xml.stream.XMLInputFactory.newInstance();
+		var f = SecureXMLInputFactory.newInstance();
 		try (var sr = new StringReader(xml)) {
 			var r = f.createXMLStreamReader(sr);
 			r.next(); // PROCESSING_INSTRUCTION
@@ -458,7 +459,7 @@ class XmlUtils_Test extends TestBase {
 	// COMMENT (event type 5) — need coalescing=false and IS_SUPPORTING_EXTERNAL_ENTITIES=false
 	@Test void h03_toReadableEvent_comment() throws Exception {
 		var xml = "<!-- my comment --><root/>";
-		var f = javax.xml.stream.XMLInputFactory.newInstance();
+		var f = SecureXMLInputFactory.newInstance();
 		f.setProperty(javax.xml.stream.XMLInputFactory.IS_COALESCING, Boolean.FALSE);
 		try (var sr = new StringReader(xml)) {
 			var r = f.createXMLStreamReader(sr);
@@ -472,7 +473,7 @@ class XmlUtils_Test extends TestBase {
 	// CDATA (event type 12)
 	@Test void h04_toReadableEvent_cdata() throws Exception {
 		var xml = "<root><![CDATA[cdata text]]></root>";
-		var f = javax.xml.stream.XMLInputFactory.newInstance();
+		var f = SecureXMLInputFactory.newInstance();
 		f.setProperty(javax.xml.stream.XMLInputFactory.IS_COALESCING, Boolean.FALSE);
 		try (var sr = new StringReader(xml)) {
 			var r = f.createXMLStreamReader(sr);

--- a/juneau-integration-tests/src/test/java/org/apache/juneau/XmlValidatorParser.java
+++ b/juneau-integration-tests/src/test/java/org/apache/juneau/XmlValidatorParser.java
@@ -24,6 +24,7 @@ import java.util.*;
 
 import javax.xml.stream.*;
 
+import org.apache.commons.xml.secure.SecureXMLInputFactory;
 import org.apache.juneau.commons.reflect.*;
 import org.apache.juneau.marshall.*;
 import org.apache.juneau.marshall.parser.*;
@@ -89,11 +90,8 @@ public class XmlValidatorParser extends XmlParser {
 	}
 
 	protected XMLStreamReader getStaxReader(Reader in) throws Exception {
-		var factory = XMLInputFactory.newInstance();
+		var factory = SecureXMLInputFactory.newInstance();
 		factory.setProperty("javax.xml.stream.isNamespaceAware", false);
-		// This validator only checks well-formedness of serializer output (which never contains DTDs), so DTD processing and external-entity resolution are disabled to close the XXE surface.
-		factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-		factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
 		var parser = factory.createXMLStreamReader(in);
 		parser.nextTag();
 		return parser;

--- a/juneau-integration-tests/src/test/java/org/apache/juneau/XmlValidatorParser_Security_Test.java
+++ b/juneau-integration-tests/src/test/java/org/apache/juneau/XmlValidatorParser_Security_Test.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.juneau;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.net.*;
+import java.nio.charset.*;
+import java.nio.file.*;
+import java.util.concurrent.atomic.*;
+
+import javax.xml.stream.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+import com.sun.net.httpserver.*;
+
+/**
+ * Exercises the independent StAX path used to validate serialized XML in integration tests.
+ */
+class XmlValidatorParser_Security_Test extends TestBase {
+
+	private HttpServer server;
+	private final AtomicInteger requests = new AtomicInteger();
+	private String external;
+
+	@BeforeEach void startServer() throws Exception {
+		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/external", exchange -> {
+			requests.incrementAndGet();
+			var body = "<!ENTITY injected 'FETCHED'>".getBytes(StandardCharsets.UTF_8);
+			exchange.sendResponseHeaders(200, body.length);
+			try (var stream = exchange.getResponseBody()) {
+				stream.write(body);
+			}
+		});
+		server.start();
+		external = "http://127.0.0.1:" + server.getAddress().getPort() + "/external";
+	}
+
+	@AfterEach void stopServer() {
+		if (server != null)
+			server.stop(0);
+	}
+
+	private static String externalDocument(String vector, String uri) {
+		return switch (vector) {
+			case "general" -> "<!DOCTYPE A [<!ENTITY ext SYSTEM '" + uri + "'>]><A>&ext;</A>";
+			case "parameter" -> "<!DOCTYPE A [<!ENTITY % ext SYSTEM '" + uri + "'>%ext;]><A>safe</A>";
+			case "systemDtd" -> "<!DOCTYPE A SYSTEM '" + uri + "'><A>safe</A>";
+			case "publicDtd" -> "<!DOCTYPE A PUBLIC '-//Juneau//DTD XXE Test//EN' '" + uri + "'><A>safe</A>";
+			default -> throw new IllegalArgumentException(vector);
+		};
+	}
+
+	private static String expansionDocument() {
+		// 100,000 leaf expansions exceed the JDK 17/21 default count, but stay small if protection regresses.
+		var dtd = new StringBuilder("<!DOCTYPE A [<!ENTITY e0 'x'>");
+		for (int i = 1; i <= 5; i++)
+			dtd.append("<!ENTITY e").append(i).append(" '").append(("&e" + (i - 1) + ";").repeat(10)).append("'>");
+		return dtd.append("]><A>&e5;</A>").toString();
+	}
+
+	@Test void ordinaryXmlStillValidates() throws Exception {
+		new XmlValidatorParser().validate(new StringReader("<A>safe &amp; sound</A>"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"general", "parameter", "systemDtd", "publicDtd"})
+	void externalReferencesNeverFetch(String vector) throws Exception {
+		try {
+			new XmlValidatorParser().validate(new StringReader(externalDocument(vector, external)));
+		} catch (XMLStreamException expected) {
+			// Empty resolution or rejection is allowed, but fetching before rejection is not.
+		}
+		assertEquals(0, requests.get(), vector + " fetched an external resource");
+	}
+
+	@Test void fileEntityIsNotExpanded(@TempDir Path directory) throws Exception {
+		var secret = directory.resolve("secret.txt");
+		Files.writeString(secret, "PRIVATE_FILE_MARKER");
+		try {
+			var reader = new XmlValidatorParser().getStaxReader(new StringReader(externalDocument("general", secret.toUri().toString())));
+			try {
+				while (reader.hasNext()) {
+					reader.next();
+					if (reader.hasText())
+						assertFalse(reader.getText().contains("PRIVATE_FILE_MARKER"));
+				}
+			} finally {
+				reader.close();
+			}
+		} catch (XMLStreamException expected) {
+			for (Throwable cause = expected; cause != null; cause = cause.getCause())
+				assertFalse(cause.toString().contains("PRIVATE_FILE_MARKER"));
+		}
+	}
+
+	@Test
+	@Timeout(10)
+	void exponentialEntityExpansionIsRejected() {
+		assertThrows(XMLStreamException.class, () -> new XmlValidatorParser().validate(new StringReader(expansionDocument())));
+	}
+}

--- a/juneau-rest/juneau-rest-server-auth-saml/src/main/java/org/apache/juneau/rest/server/auth/saml/SamlAssertionValidator.java
+++ b/juneau-rest/juneau-rest-server-auth-saml/src/main/java/org/apache/juneau/rest/server/auth/saml/SamlAssertionValidator.java
@@ -27,7 +27,7 @@ import java.util.logging.*;
 
 import javax.xml.namespace.*;
 import javax.xml.parsers.*;
-
+import org.apache.commons.xml.secure.SecureDocumentBuilderFactory;
 import org.apache.juneau.commons.concurrent.*;
 import org.apache.juneau.rest.server.auth.*;
 import org.opensaml.core.criterion.*;
@@ -562,13 +562,7 @@ public class SamlAssertionValidator {
 
 	private Response parseResponse(String xml) throws AuthenticationException {
 		try {
-			var dbf = DocumentBuilderFactory.newInstance();
-			dbf.setNamespaceAware(true);
-			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-			dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-			dbf.setXIncludeAware(false);
-			dbf.setExpandEntityReferences(false);
+			var dbf = SecureDocumentBuilderFactory.newNSInstance();
 			var doc = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(xml.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
 			Element root = doc.getDocumentElement();
 			var registry = org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport.getUnmarshallerFactory();

--- a/juneau-rest/juneau-rest-server-auth-saml/src/main/java/org/apache/juneau/rest/server/auth/saml/SamlMetadataResolvers.java
+++ b/juneau-rest/juneau-rest-server-auth-saml/src/main/java/org/apache/juneau/rest/server/auth/saml/SamlMetadataResolvers.java
@@ -29,7 +29,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import javax.xml.parsers.*;
-
+import org.apache.commons.xml.secure.SecureDocumentBuilderFactory;
 import org.apache.juneau.commons.utils.*;
 import org.opensaml.saml.metadata.resolver.*;
 import org.opensaml.saml.metadata.resolver.filter.*;
@@ -196,13 +196,7 @@ public final class SamlMetadataResolvers {
 			if (resp.statusCode() < 200 || resp.statusCode() >= 300) // HTT: false branch (2xx success) requires live SAML metadata endpoint; covered by integration tests
 				throw ioex("Failed to fetch SAML metadata from %s (HTTP %s)", url, resp.statusCode());
 
-			var dbf = DocumentBuilderFactory.newInstance();
-			dbf.setNamespaceAware(true);
-			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-			dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-			dbf.setXIncludeAware(false);
-			dbf.setExpandEntityReferences(false);
+			var dbf = SecureDocumentBuilderFactory.newNSInstance();
 			var doc = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(resp.body()));
 			Element root = doc.getDocumentElement();
 

--- a/juneau-rest/juneau-rest-server-auth-saml/src/test/java/org/apache/juneau/rest/server/auth/saml/SamlTestSupport.java
+++ b/juneau-rest/juneau-rest-server-auth-saml/src/test/java/org/apache/juneau/rest/server/auth/saml/SamlTestSupport.java
@@ -24,6 +24,7 @@ import javax.xml.transform.*;
 import javax.xml.transform.dom.*;
 import javax.xml.transform.stream.*;
 
+import org.apache.commons.xml.secure.SecureTransformerFactory;
 import org.opensaml.core.config.*;
 import org.opensaml.core.xml.config.*;
 import org.opensaml.core.xml.io.*;
@@ -291,7 +292,7 @@ final class SamlTestSupport {
 
 	private static String serialize(org.w3c.dom.Element dom) throws Exception {
 		var sw = new StringWriter();
-		var tf = TransformerFactory.newInstance();
+		var tf = SecureTransformerFactory.newInstance();
 		var transformer = tf.newTransformer();
 		transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 		transformer.transform(new DOMSource(dom), new StreamResult(sw));
@@ -352,7 +353,7 @@ final class SamlTestSupport {
 
 		// Serialize to XML string.
 		var sw = new StringWriter();
-		var tf = TransformerFactory.newInstance();
+		var tf = SecureTransformerFactory.newInstance();
 		var transformer = tf.newTransformer();
 		transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 		transformer.transform(new DOMSource(dom), new StreamResult(sw));

--- a/juneau-rest/juneau-rest-server-auth-saml/src/test/java/org/apache/juneau/rest/server/auth/saml/SamlXmlSecurity_Test.java
+++ b/juneau-rest/juneau-rest-server-auth-saml/src/test/java/org/apache/juneau/rest/server/auth/saml/SamlXmlSecurity_Test.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.juneau.rest.server.auth.saml;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.net.*;
+import java.nio.charset.*;
+import java.nio.file.*;
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+import org.apache.juneau.*;
+import org.apache.juneau.rest.server.auth.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.opensaml.core.criterion.*;
+import org.opensaml.saml.metadata.resolver.impl.*;
+import org.opensaml.security.credential.*;
+import org.xml.sax.*;
+
+import com.sun.net.httpserver.*;
+
+import net.shibboleth.shared.resolver.*;
+
+/**
+ * Checks the DOM parsing boundaries for SAML responses and remotely loaded metadata.
+ */
+class SamlXmlSecurity_Test extends TestBase {
+
+	private static final String ISSUER = "https://idp.example.com";
+	private static final String AUDIENCE = "https://sp.example.com";
+	private static final Instant NOW = Instant.parse("2026-01-01T00:00:00Z");
+	private static final String METADATA = "<EntityDescriptor xmlns='urn:oasis:names:tc:SAML:2.0:metadata' entityID='" + ISSUER + "'>"
+		+ "<IDPSSODescriptor protocolSupportEnumeration='urn:oasis:names:tc:SAML:2.0:protocol'>"
+		+ "<SingleSignOnService Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect' Location='https://idp.example.com/sso'/>"
+		+ "</IDPSSODescriptor><Organization><OrganizationName xml:lang='en'>safe</OrganizationName>"
+		+ "<OrganizationDisplayName xml:lang='en'>safe</OrganizationDisplayName>"
+		+ "<OrganizationURL xml:lang='en'>https://idp.example.com</OrganizationURL></Organization></EntityDescriptor>";
+	private BasicCredential credential;
+	private String signedResponse;
+	private volatile String metadataBody;
+	private String metadataUrl;
+	private final AtomicInteger metadataRequests = new AtomicInteger();
+
+	private HttpServer server;
+	private final AtomicInteger requests = new AtomicInteger();
+	private String external;
+
+	@BeforeEach void startServer() throws Exception {
+		server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/external", exchange -> {
+			requests.incrementAndGet();
+			var body = "<!ENTITY injected 'FETCHED'>".getBytes(StandardCharsets.UTF_8);
+			exchange.sendResponseHeaders(200, body.length);
+			try (var stream = exchange.getResponseBody()) {
+				stream.write(body);
+			}
+		});
+		server.createContext("/metadata", exchange -> {
+			metadataRequests.incrementAndGet();
+			var body = metadataBody.getBytes(StandardCharsets.UTF_8);
+			exchange.sendResponseHeaders(200, body.length);
+			try (var stream = exchange.getResponseBody()) {
+				stream.write(body);
+			}
+		});
+		server.start();
+		external = "http://127.0.0.1:" + server.getAddress().getPort() + "/external";
+		metadataUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/metadata";
+		metadataBody = METADATA;
+		credential = SamlTestSupport.credential(SamlTestSupport.generateRsaKeyPair());
+		signedResponse = SamlTestSupport.buildSignedResponse(credential, ISSUER, AUDIENCE, "alice",
+			NOW.minusSeconds(60), NOW.plusSeconds(300), Map.of());
+	}
+
+	@AfterEach void stopServer() {
+		if (server != null)
+			server.stop(0);
+	}
+
+	private SamlAssertionValidator validator() {
+		return SamlAssertionValidator.create().spEntityId(AUDIENCE).expectedIssuer(ISSUER)
+			.signingCredential(credential).clock(Clock.fixed(NOW, ZoneOffset.UTC)).build();
+	}
+
+	private static String rootName(String xml) {
+		return xml.substring(1, xml.indexOf(' '));
+	}
+
+	private static String attack(String xml, String vector, String uri, String marker) {
+		var root = rootName(xml);
+		return switch (vector) {
+			case "general" -> "<!DOCTYPE " + root + " [<!ENTITY ext SYSTEM '" + uri + "'>]>" + xml.replace(marker, "&ext;");
+			case "parameter" -> "<!DOCTYPE " + root + " [<!ENTITY % ext SYSTEM '" + uri + "'>%ext;]>" + xml;
+			case "systemDtd" -> "<!DOCTYPE " + root + " SYSTEM '" + uri + "'>" + xml;
+			case "publicDtd" -> "<!DOCTYPE " + root + " PUBLIC '-//Juneau//DTD XXE Test//EN' '" + uri + "'>" + xml;
+			case "xincludeXml", "xincludeText" -> xml.replace(marker,
+				"<xi:include xmlns:xi='http://www.w3.org/2001/XInclude' href='" + uri + "' parse='"
+				+ (vector.equals("xincludeXml") ? "xml" : "text") + "'/>");
+			case "schemaLocation" -> xml.replaceFirst(" ", " xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='"
+				+ "urn:oasis:names:tc:SAML:2.0:metadata " + uri + " urn:oasis:names:tc:SAML:2.0:protocol " + uri + "' ");
+			case "noNamespaceSchemaLocation" -> xml.replaceFirst(" ",
+				" xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='" + uri + "' ");
+			default -> throw new IllegalArgumentException(vector);
+		};
+	}
+
+	private String readMetadata() throws Exception {
+		var resolver = SamlMetadataResolvers.url(metadataUrl);
+		try {
+			var entity = resolver.resolveSingle(new CriteriaSet(new EntityIdCriterion(ISSUER)));
+			assertNotNull(entity, "The metadata fixture must resolve successfully");
+			return entity.getOrganization().getOrganizationNames().get(0).getValue();
+		} finally {
+			((DOMMetadataResolver) resolver).destroy();
+		}
+	}
+
+	@Test void ordinaryDocumentsStillWork() throws Exception {
+		assertEquals("alice", validator().validate(signedResponse).getName());
+		assertEquals("safe", readMetadata());
+		assertEquals(1, metadataRequests.get());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"general", "parameter", "systemDtd", "publicDtd", "xincludeXml", "xincludeText",
+		"schemaLocation", "noNamespaceSchemaLocation"})
+	void responseReferencesNeverFetch(String vector) throws Exception {
+		var v = validator();
+		try {
+			v.validate(attack(signedResponse, vector, external, "alice"));
+		} catch (AuthenticationException expected) {
+			// Signature or XML rejection is safe only if no external access happened first.
+		}
+		assertEquals(0, requests.get(), vector + " fetched an external resource");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"general", "parameter", "systemDtd", "publicDtd", "xincludeXml", "xincludeText",
+		"schemaLocation", "noNamespaceSchemaLocation"})
+	void metadataReferencesNeverFetch(String vector) throws Exception {
+		metadataBody = attack(METADATA, vector, external, "safe");
+		try {
+			readMetadata();
+		} catch (IOException expected) {
+			// Both rejection and ignoring a reference are permitted.
+		}
+		assertEquals(1, metadataRequests.get(), "The intended top-level metadata must be fetched");
+		assertEquals(0, requests.get(), vector + " fetched an external resource");
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"general", "parameter", "systemDtd", "publicDtd", "xincludeText"})
+	void responseFileReferencesCannotSupplySignedSubject(String vector, @TempDir Path directory) throws Exception {
+		var file = directory.resolve("external.txt");
+		Files.writeString(file, vector.equals("general") || vector.equals("xincludeText") ? "alice" : "<!ENTITY subject 'alice'>");
+		var xml = attack(signedResponse, vector, file.toUri().toString(), "alice");
+		if (!vector.equals("general") && !vector.equals("xincludeText"))
+			xml = xml.replace("alice", "&subject;");
+		var input = xml;
+		var v = validator();
+		// Resolving the file reconstructs the correctly signed assertion. An unrelated bad signature cannot mask a leak.
+		assertThrows(AuthenticationException.class, () -> v.validate(input));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {"general", "parameter", "systemDtd", "publicDtd", "xincludeText"})
+	void metadataFileReferencesCannotSupplyContent(String vector, @TempDir Path directory) throws Exception {
+		var file = directory.resolve("external.txt");
+		Files.writeString(file, vector.equals("general") || vector.equals("xincludeText")
+			? "PRIVATE_FILE_MARKER" : "<!ENTITY secret 'PRIVATE_FILE_MARKER'>");
+		metadataBody = attack(METADATA, vector, file.toUri().toString(), "safe");
+		if (!vector.equals("general") && !vector.equals("xincludeText"))
+			metadataBody = metadataBody.replace("safe", "&secret;");
+		try {
+			assertNotEquals("PRIVATE_FILE_MARKER", readMetadata());
+		} catch (IOException expected) {
+			for (Throwable cause = expected; cause != null; cause = cause.getCause())
+				assertFalse(cause.toString().contains("PRIVATE_FILE_MARKER"));
+		}
+	}
+
+	private static String expansion(String xml, String marker) {
+		// A bounded fixture exceeds normal expansion-count limits without generating a true gigabyte payload.
+		var dtd = new StringBuilder("<!DOCTYPE " + rootName(xml) + " [<!ENTITY e0 'x'>");
+		for (int i = 1; i <= 5; i++)
+			dtd.append("<!ENTITY e").append(i).append(" '").append(("&e" + (i - 1) + ";").repeat(10)).append("'>");
+		return dtd.append("]>").append(xml.replace(marker, "&e5;")).toString();
+	}
+
+	private static void assertXmlRejection(Throwable failure) {
+		for (Throwable cause = failure; cause != null; cause = cause.getCause())
+			if (cause instanceof SAXParseException)
+				return;
+		fail("Expected XML parser rejection, not a later SAML/signature failure", failure);
+	}
+
+	@Test
+	@Timeout(10)
+	void responseExpansionIsRejectedByXmlParser() {
+		var v = validator();
+		var xml = expansion(signedResponse, "alice");
+		assertXmlRejection(assertThrows(AuthenticationException.class, () -> v.validate(xml)));
+	}
+
+	@Test
+	@Timeout(10)
+	void metadataExpansionIsRejectedByXmlParser() {
+		metadataBody = expansion(METADATA, "safe");
+		assertXmlRejection(assertThrows(IOException.class, () -> SamlMetadataResolvers.url(metadataUrl)));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,13 @@
 			<url>file:///tmp/site</url>
 		</site>
 	</distributionManagement>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-secure-xml</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+	</dependencies>
 
 	<build>
 		<defaultGoal>clean verify</defaultGoal>


### PR DESCRIPTION
Use [Commons Secure XML](https://commons.apache.org/proper/commons-secure-xml/) instead of repeating custom JAXP configuration code pattrns to secure JAXP objects.